### PR TITLE
Refactor/ux streamlining

### DIFF
--- a/apps/pack-runner/src/App.svelte
+++ b/apps/pack-runner/src/App.svelte
@@ -24,23 +24,6 @@
   const RECORD_SET_KEY = 'augment-it:pack-runner:record-set';
   const ENTITY_FIELD_KEY = 'augment-it:pack-runner:entity-name-field';
 
-  // Shared enrichment-mode state — mirrored from prompt-template-manager so
-  // the pair panels stay in sync.
-  const ENRICHMENT_MODE_KEY = 'augment-it:enrichment-mode';
-  const ENRICHMENT_MODE_EVENT = 'augment-it:enrichment-mode';
-  type EnrichmentMode = 'prompt' | 'pack';
-
-  function readMode(): EnrichmentMode {
-    if (typeof localStorage === 'undefined') return 'pack';
-    return (localStorage.getItem(ENRICHMENT_MODE_KEY) as EnrichmentMode) ?? 'pack';
-  }
-  function setMode(mode: EnrichmentMode): void {
-    enrichmentMode = mode;
-    if (typeof localStorage !== 'undefined') localStorage.setItem(ENRICHMENT_MODE_KEY, mode);
-    window.dispatchEvent(new CustomEvent(ENRICHMENT_MODE_EVENT, { detail: { mode } }));
-  }
-  let enrichmentMode = $state<EnrichmentMode>(readMode());
-
   function readStored(key: string): string | null {
     if (typeof localStorage === 'undefined') return null;
     return localStorage.getItem(key);
@@ -122,14 +105,6 @@
       onStatus: (s) => (status = s),
     });
     void loadRecordSets();
-
-    // Listen for mode flips from the pair panel (prompt-template-manager).
-    const onMode = (e: Event) => {
-      const detail = (e as CustomEvent).detail as { mode?: EnrichmentMode } | undefined;
-      if (detail?.mode) enrichmentMode = detail.mode;
-    };
-    window.addEventListener(ENRICHMENT_MODE_EVENT, onMode);
-    return () => window.removeEventListener(ENRICHMENT_MODE_EVENT, onMode);
   });
 
   async function loadRecordSets() {
@@ -272,45 +247,6 @@
     <span class="status status-{status}">{status}</span>
   </div>
 
-  <!-- Symmetric mode-switch — icon-with-tooltip pair (spec Decision §5,
-       Phase 2b). Mirrors prompt-template-manager; shared state via the
-       augment-it:enrichment-mode window event + localStorage so both pair
-       panels reflect the same selection. The Custom Prompt option also
-       dispatches augment-it:navigate so the focused pane swaps in the
-       split. -->
-  <div class="pr-mode-switch" role="tablist" aria-label="Enrichment mode">
-    <button
-      class="pr-mode"
-      class:active={enrichmentMode === 'prompt'}
-      role="tab"
-      aria-selected={enrichmentMode === 'prompt'}
-      aria-label="Custom prompt — author a free-text LLM prompt"
-      title="Custom prompt — author a free-text LLM prompt"
-      onclick={() => {
-        setMode('prompt');
-        window.dispatchEvent(
-          new CustomEvent('augment-it:navigate', {
-            detail: { remoteId: 'promptTemplateManager' },
-          }),
-        );
-      }}
-    >
-      <span aria-hidden="true">✎</span>
-    </button>
-    <button
-      class="pr-mode"
-      class:active={enrichmentMode === 'pack'}
-      role="tab"
-      aria-selected={enrichmentMode === 'pack'}
-      aria-label="Pre-built pack — fire a source-bound pack against the record set"
-      title="Pre-built pack — fire a source-bound pack against the record set"
-      onclick={() => setMode('pack')}
-    >
-      <span aria-hidden="true">⊞</span>
-    </button>
-  </div>
-
-  {#if enrichmentMode === 'pack'}
   <div class="pr-body">
     <div class="pr-head">
       <h2>Pack Runner</h2>
@@ -452,5 +388,4 @@
       </section>
     {/if}
   </div>
-  {/if}
 </div>

--- a/apps/pack-runner/src/App.svelte
+++ b/apps/pack-runner/src/App.svelte
@@ -272,15 +272,20 @@
     <span class="status status-{status}">{status}</span>
   </div>
 
-  <!-- Symmetric mode-switch — mirrors prompt-template-manager. Shared
-       state via the augment-it:enrichment-mode window event + localStorage
-       so both pair panels reflect the same selection. -->
+  <!-- Symmetric mode-switch — icon-with-tooltip pair (spec Decision §5,
+       Phase 2b). Mirrors prompt-template-manager; shared state via the
+       augment-it:enrichment-mode window event + localStorage so both pair
+       panels reflect the same selection. The Custom Prompt option also
+       dispatches augment-it:navigate so the focused pane swaps in the
+       split. -->
   <div class="pr-mode-switch" role="tablist" aria-label="Enrichment mode">
     <button
       class="pr-mode"
       class:active={enrichmentMode === 'prompt'}
       role="tab"
       aria-selected={enrichmentMode === 'prompt'}
+      aria-label="Custom prompt — author a free-text LLM prompt"
+      title="Custom prompt — author a free-text LLM prompt"
       onclick={() => {
         setMode('prompt');
         window.dispatchEvent(
@@ -289,21 +294,23 @@
           }),
         );
       }}
-      title="Author a custom LLM prompt instead of using a pre-built pack"
     >
-      ← Custom Prompt
+      <span aria-hidden="true">✎</span>
     </button>
     <button
       class="pr-mode"
       class:active={enrichmentMode === 'pack'}
       role="tab"
       aria-selected={enrichmentMode === 'pack'}
+      aria-label="Pre-built pack — fire a source-bound pack against the record set"
+      title="Pre-built pack — fire a source-bound pack against the record set"
       onclick={() => setMode('pack')}
     >
-      Pre-built Pack
+      <span aria-hidden="true">⊞</span>
     </button>
   </div>
 
+  {#if enrichmentMode === 'pack'}
   <div class="pr-body">
     <div class="pr-head">
       <h2>Pack Runner</h2>
@@ -445,4 +452,5 @@
       </section>
     {/if}
   </div>
+  {/if}
 </div>

--- a/apps/pack-runner/src/app.css
+++ b/apps/pack-runner/src/app.css
@@ -11,42 +11,8 @@
 }
 
 /* Enrichment-mode switch — symmetric with prompt-template-manager. */
-.pr-app .pr-mode-switch {
-  display: flex;
-  gap: 0.4rem;
-  padding: 0.5rem 1.5rem;
-  border-bottom: 1px solid var(--color-border);
-  background: var(--color-background);
-}
-
-.pr-app .pr-mode {
-  background: transparent;
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  width: 1.9rem;
-  height: 1.9rem;
-  padding: 0;
-  border-radius: 6px;
-  font-size: 1rem;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
-.pr-app .pr-mode:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-}
-.pr-app .pr-mode.active {
-  background: var(--color-accent);
-  color: var(--color-on-accent);
-  border-color: var(--color-accent);
-  cursor: default;
-}
-.pr-app .pr-mode.active:hover {
-  color: var(--color-on-accent);
-}
+/* Enrichment-mode switch moved to packages/shared-ui (Phase 2c). The shell
+ * renders it as the composite slot's header above Pack Runner. */
 
 .pr-app .pr-body { padding: 1.25rem 1.5rem; max-width: 900px; }
 

--- a/apps/pack-runner/src/app.css
+++ b/apps/pack-runner/src/app.css
@@ -23,11 +23,16 @@
   background: transparent;
   color: var(--color-text-muted);
   border: 1px solid var(--color-border);
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  font-size: 0.8rem;
+  width: 1.9rem;
+  height: 1.9rem;
+  padding: 0;
+  border-radius: 6px;
+  font-size: 1rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
-  letter-spacing: 0.02em;
 }
 .pr-app .pr-mode:hover {
   border-color: var(--color-accent);

--- a/apps/prompt-template-manager/src/App.svelte
+++ b/apps/prompt-template-manager/src/App.svelte
@@ -226,27 +226,33 @@
     </span>
   </div>
 
-  <!-- Enrichment-mode switch — per [[Run-as-First-Class-Operation]] §Part 1:
-       prompt-template-manager and pack-runner are the two ways to enrich a
-       record set. The switch surfaces both as discoverable options here so
-       the user picks the flavor without hunting for a separate tile. The
-       Pack option dispatches the existing augment-it:navigate event; the
-       shell catches it and opens the prompt-templates ⇄ pack-runner pair. -->
+  <!-- Enrichment-mode switch — icon-with-tooltip pair (spec Decision §5,
+       Phase 2b). Custom Prompt and Pre-built Pack are peer alternatives
+       for enriching a record set; the small-control icon pattern is the
+       shell-wide affordance for binary picks (also used by Decision §8's
+       Split/Full layout toggles). Shared state via the
+       augment-it:enrichment-mode window event + localStorage; the Pack
+       option also dispatches augment-it:navigate so the shell opens the
+       prompt-templates ⇄ pack-runner pair. -->
   <div class="ptm-mode-switch" role="tablist" aria-label="Enrichment mode">
     <button
       class="ptm-mode"
       class:active={enrichmentMode === 'prompt'}
       role="tab"
       aria-selected={enrichmentMode === 'prompt'}
+      aria-label="Custom prompt — author a free-text LLM prompt"
+      title="Custom prompt — author a free-text LLM prompt"
       onclick={() => setMode('prompt')}
     >
-      Custom Prompt
+      <span aria-hidden="true">✎</span>
     </button>
     <button
       class="ptm-mode"
       class:active={enrichmentMode === 'pack'}
       role="tab"
       aria-selected={enrichmentMode === 'pack'}
+      aria-label="Pre-built pack — fire a source-bound pack against the record set"
+      title="Pre-built pack — fire a source-bound pack against the record set"
       onclick={() => {
         setMode('pack');
         window.dispatchEvent(
@@ -255,12 +261,12 @@
           }),
         );
       }}
-      title="Use a pre-built source-bound pack instead of authoring a custom prompt"
     >
-      Pre-built Pack →
+      <span aria-hidden="true">⊞</span>
     </button>
   </div>
 
+  {#if enrichmentMode === 'prompt'}
   <div class="ptm-layout">
     <aside>
       <h2>Prompts</h2>
@@ -355,4 +361,5 @@
       {/if}
     </section>
   </div>
+  {/if}
 </div>

--- a/apps/prompt-template-manager/src/App.svelte
+++ b/apps/prompt-template-manager/src/App.svelte
@@ -6,24 +6,6 @@
   const WS_URL = 'ws://localhost:3001/ws';
   const TOKEN_RE = /\{\{\s*([^{}]+?)\s*\}\}/g;
 
-  // Shared "which enrichment mode is selected" state, mirrored in pack-runner.
-  // Persisted to localStorage + broadcast via window event so the pair
-  // panels stay in sync without a transport round-trip.
-  const ENRICHMENT_MODE_KEY = 'augment-it:enrichment-mode';
-  const ENRICHMENT_MODE_EVENT = 'augment-it:enrichment-mode';
-  type EnrichmentMode = 'prompt' | 'pack';
-
-  function readMode(): EnrichmentMode {
-    if (typeof localStorage === 'undefined') return 'prompt';
-    return (localStorage.getItem(ENRICHMENT_MODE_KEY) as EnrichmentMode) ?? 'prompt';
-  }
-  function setMode(mode: EnrichmentMode): void {
-    enrichmentMode = mode;
-    if (typeof localStorage !== 'undefined') localStorage.setItem(ENRICHMENT_MODE_KEY, mode);
-    window.dispatchEvent(new CustomEvent(ENRICHMENT_MODE_EVENT, { detail: { mode } }));
-  }
-  let enrichmentMode = $state<EnrichmentMode>(readMode());
-
   let status = $state<'connecting' | 'open' | 'closed' | 'error'>('connecting');
 
   // editor state — selectedPromptId null means "new, unsaved"
@@ -80,14 +62,6 @@
       onStatus: (s) => (status = s),
     });
     void refreshPrompts();
-
-    // Listen for mode flips from the pair panel (pack-runner).
-    const onMode = (e: Event) => {
-      const detail = (e as CustomEvent).detail as { mode?: EnrichmentMode } | undefined;
-      if (detail?.mode) enrichmentMode = detail.mode;
-    };
-    window.addEventListener(ENRICHMENT_MODE_EVENT, onMode);
-    return () => window.removeEventListener(ENRICHMENT_MODE_EVENT, onMode);
   });
 
   // prompt CRUD events — seq-cursor dedup so a stale event re-fire on any
@@ -226,47 +200,6 @@
     </span>
   </div>
 
-  <!-- Enrichment-mode switch — icon-with-tooltip pair (spec Decision §5,
-       Phase 2b). Custom Prompt and Pre-built Pack are peer alternatives
-       for enriching a record set; the small-control icon pattern is the
-       shell-wide affordance for binary picks (also used by Decision §8's
-       Split/Full layout toggles). Shared state via the
-       augment-it:enrichment-mode window event + localStorage; the Pack
-       option also dispatches augment-it:navigate so the shell opens the
-       prompt-templates ⇄ pack-runner pair. -->
-  <div class="ptm-mode-switch" role="tablist" aria-label="Enrichment mode">
-    <button
-      class="ptm-mode"
-      class:active={enrichmentMode === 'prompt'}
-      role="tab"
-      aria-selected={enrichmentMode === 'prompt'}
-      aria-label="Custom prompt — author a free-text LLM prompt"
-      title="Custom prompt — author a free-text LLM prompt"
-      onclick={() => setMode('prompt')}
-    >
-      <span aria-hidden="true">✎</span>
-    </button>
-    <button
-      class="ptm-mode"
-      class:active={enrichmentMode === 'pack'}
-      role="tab"
-      aria-selected={enrichmentMode === 'pack'}
-      aria-label="Pre-built pack — fire a source-bound pack against the record set"
-      title="Pre-built pack — fire a source-bound pack against the record set"
-      onclick={() => {
-        setMode('pack');
-        window.dispatchEvent(
-          new CustomEvent('augment-it:navigate', {
-            detail: { remoteId: 'packRunner' },
-          }),
-        );
-      }}
-    >
-      <span aria-hidden="true">⊞</span>
-    </button>
-  </div>
-
-  {#if enrichmentMode === 'prompt'}
   <div class="ptm-layout">
     <aside>
       <h2>Prompts</h2>
@@ -361,5 +294,4 @@
       {/if}
     </section>
   </div>
-  {/if}
 </div>

--- a/apps/prompt-template-manager/src/app.css
+++ b/apps/prompt-template-manager/src/app.css
@@ -222,11 +222,16 @@
   background: transparent;
   color: var(--color-text-muted);
   border: 1px solid var(--color-border);
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  font-size: 0.8rem;
+  width: 1.9rem;
+  height: 1.9rem;
+  padding: 0;
+  border-radius: 6px;
+  font-size: 1rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
-  letter-spacing: 0.02em;
 }
 .ptm-app .ptm-mode:hover {
   border-color: var(--color-accent);

--- a/apps/prompt-template-manager/src/app.css
+++ b/apps/prompt-template-manager/src/app.css
@@ -205,45 +205,5 @@
   border-radius: 4px;
 }
 
-/* -----------------------------------------------------------------------------
- * Enrichment-mode switch — Custom Prompt (active) vs Pre-built Pack (link
- * out to pack-runner via augment-it:navigate). Spec:
- * context-v/plans/Run-as-First-Class-Operation.md §Part 1
- * -------------------------------------------------------------------------- */
-.ptm-app .ptm-mode-switch {
-  display: flex;
-  gap: 0.4rem;
-  padding: 0.5rem 1.5rem;
-  border-bottom: 1px solid var(--color-border);
-  background: var(--color-background);
-}
-
-.ptm-app .ptm-mode {
-  background: transparent;
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  width: 1.9rem;
-  height: 1.9rem;
-  padding: 0;
-  border-radius: 6px;
-  font-size: 1rem;
-  line-height: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-}
-.ptm-app .ptm-mode:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-}
-.ptm-app .ptm-mode.active {
-  background: var(--color-accent);
-  color: var(--color-on-accent);
-  border-color: var(--color-accent);
-  cursor: default;
-}
-.ptm-app .ptm-mode.active:hover {
-  /* don't tint when already active */
-  color: var(--color-on-accent);
-}
+/* Enrichment-mode switch moved to packages/shared-ui as ToggleHeader__PromptOrPackage--Icons
+ * (Phase 2c). The shell renders it as the composite slot's header. */

--- a/changelog/2026-06-01_03_Composite-Slots-and-the-Flow-Rename.md
+++ b/changelog/2026-06-01_03_Composite-Slots-and-the-Flow-Rename.md
@@ -1,0 +1,412 @@
+---
+date_created: 2026-06-01
+date_modified: 2026-06-01
+title: "Composite Slots & the Flow Rename — One Toggle, Every Layout Mode"
+lede: "We thought the spec called for two patches and a rename. Halfway through the second patch the architecture broke in our face — a Split view with a working ✎/⊞ toggle but a stubbornly empty pane next to it — and we realized the toggle didn't belong inside either remote, it belonged to the slot. The fix turned into a shell-level concept that pays off in every layout mode."
+publish: true
+authors:
+  - Michael Staton
+augmented_with:
+  - Claude Code on Claude Opus 4.7
+files_changed:
+  - context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
+  - shell/src/App.svelte
+  - shell/src/layout.svelte.ts
+  - shell/src/remotes.ts
+  - shell/src/composites.ts
+  - shell/package.json
+  - packages/shared-ui/src/ToggleHeader__PromptOrPackage--Icons.svelte
+  - packages/shared-ui/package.json
+  - apps/prompt-template-manager/src/App.svelte
+  - apps/prompt-template-manager/src/app.css
+  - apps/pack-runner/src/App.svelte
+  - apps/pack-runner/src/app.css
+---
+
+# Composite Slots & the Flow Rename
+
+## Why Care?
+
+If you've used augment-it, you've felt the moment where you pick "Pre-built
+Pack →" inside Prompt Templates, the right pane lights up Pack Runner, and
+**the left pane stays showing the prompt editor underneath**. Two flows
+compete for the eye, the seam is uglier than the work, and you start to
+wonder which thing you're actually about to fire.
+
+This shipment fixes that. The enrichment surface is now a single slot in the
+shell — Prompt Templates *or* Pack Runner, never both — with a tiny ✎/⊞
+toggle at the top of the slot that swaps which one you see. And because the
+toggle is owned by the slot rather than by either remote, it works the same
+way in **Flow** (left-to-right workflow), **Split** (two cooperating
+panes), and **Full** (one pane, full bleed). It's the same control no
+matter which perspective you're in.
+
+We also rebranded the top-left mode segment from **Deck / Split / Full** to
+**Flow / Split / Full**. "Deck" connoted *presentation slides*; the actual
+interaction is a left-to-right workflow — Record Collector → Enrichment →
+Request Reviewer → Response Reviewer → Enhanced Records. "Flow" matches
+the model, and it sets up the next phase (a numbered bubble progress strip
+showing *where you are* in the workflow).
+
+## What's New?
+
+- **Deck → Flow** across the shell, with a one-line localStorage migration
+  so existing layout preferences survive the rename.
+- **Peek-deck position labels** ("REQUEST REVIEWER", and the analogous
+  per-pane labels for every neighbour) now **anchor to the slice's left
+  margin** instead of floating in the center. They read as landmarks, not
+  floating titles.
+- **Composite slot** — a new shell-level concept. A slot can host
+  one-of-N remotes based on shared state. The shell renders a tiny
+  icon-with-tooltip toggle as the slot's header and mounts only the active
+  member.
+- **`ENRICHMENT` composite** — `{ Prompt Templates, Pack Runner }` with the
+  ✎ / ⊞ toggle. Replaces the old "pair of side-by-side enrichment remotes"
+  pattern. Default member: Pack Runner.
+- **Shared-UI component** `ToggleHeader__PromptOrPackage--Icons.svelte` —
+  pure presentation, lives in `@augment-it/shared-ui` so anything else that
+  needs a binary-icon header can reuse it.
+- **Composites are peers in the Flow rotation.** Introduced `ROTATION` as
+  an ordered list of slot ids (remotes *and* composites). The rotation is
+  now: Record Collector → **Enrichment** → Request Reviewer → Response
+  Reviewer → Enhanced Records.
+- **Cross-remote navigation aware of composites.** Dispatching
+  `augment-it:navigate { remoteId: 'packRunner' }` from anywhere in the
+  app now sets Enrichment's active member to Pack Runner *and* focuses
+  the Enrichment slot — whether you land there in Flow, Split, or Full.
+
+All on the new `refactor/ux-streamlining` branch, with a plan doc that
+tracks the six phases and the spike that resolved itself in the act of
+trying to ship around it.
+
+## How It Works
+
+### A spec, then a plan, then a fork in the road
+
+A few days ago, prepping a demo, we hit a chain of small "I can't
+find / reach / trigger X" failures across Pack Runner, Enhanced Records,
+and Response Reviewer. Each one was a one-line patch. Together they told
+us the shell's affordances had a coherence problem. We wrote that up as
+the [[Shell-and-Micro-Frontend-UX-Coherence]] audit spec — eight locked
+decisions, twelve pieces of evidence, four named failure shapes
+(`hidden`, `dead`, `mismatched`, and the emerging `misnamed`).
+
+This week we sequenced those eight decisions into a six-phase refactor
+plan and cut the `refactor/ux-streamlining` branch off the current tip.
+The phases, briefly:
+
+```
+Phase 0 — branch + plan                              ✅ committed
+Phase 1 — Deck → Flow rename (vocabulary foundation) ✅ shipped
+Phase 2 — mechanical polish:
+  2a — peek labels anchor left                       ✅ shipped
+  2b — enrichment icon-switcher (intra-remote)       ↩︎ superseded
+  2c — composite slot + shared toggle                ✅ shipped
+  2d — composites are peers in Flow rotation         ✅ shipped
+Phase 3 — bundle-first Pack Runner                   ⏳ next
+Phase 4 — hierarchical Flow widget (Decision §8)     ⏳
+Phase 5 — Augment This Set                           ⏳
+Phase 6 — principles + audit harvest                 ⏳
+```
+
+The story below is the journey through Phase 2.
+
+### Phase 1 — Deck → Flow
+
+The smallest possible change: rename the literal `'Deck'` button label,
+rename the `LayoutMode` type literal `'peek-deck'` to `'peek-flow'`,
+update the comments that name the mode, and add a one-line migration in
+`readStored()` so any persisted `'peek-deck'` value maps to `'peek-flow'`
+on read.
+
+```ts
+// shell/src/layout.svelte.ts
+function migrateMode(mode: unknown): LayoutMode | undefined {
+  if (mode === 'peek-deck') return 'peek-flow';
+  if (mode === 'peek-flow' || mode === 'co-existence' || mode === 'full') return mode;
+  return undefined;
+}
+```
+
+The historical context-v doc `Build-the-Shell-Tiling-and-Peek-Deck.md`
+stays — its filename is its identity, and renaming the doc to chase the
+new vocabulary is exactly the sort of "going around fixing old things"
+we try to avoid.
+
+### Phase 2a — Peek labels anchor left
+
+Spec Decision §6: the vertical per-pane labels (the ones reading top-to-
+bottom in each peek slice — "REQUEST REVIEWER", "RECORD COLLECTOR",
+etc.) had been horizontally centered in the slice since the first cut
+of the tiling shell. Floating in the middle of nothing. The user named
+this the canonical example of *"things we did early and never came
+back to"* — a category of UX debt this audit keeps flagging.
+
+```css
+/* shell/src/App.svelte */
+.peek-overlay {
+  /* was: justify-content: center */
+  justify-content: flex-start;
+  padding-left: 0.75rem;  /* sit in a small gutter, not flush */
+}
+```
+
+Small change, but the landmarks now sit where the eye looks for them.
+
+### Phase 2b — the first attempt that wasn't quite right
+
+The spec calls for the Prompt Templates ⇄ Pack Runner enrichment pair to
+become **exclusive UI**: when you're in pack mode the prompt editor
+hides, and vice versa. The two large mode-tab buttons at the top of each
+pane collapse into a small icon-with-tooltip pair.
+
+We shipped that — inside each remote. PTM got the ✎/⊞ icon-switcher,
+wrapped its body in `{#if enrichmentMode === 'prompt'}`. Pack Runner got
+the symmetric treatment. Builds clean, tooltips read well, the icons
+are tight.
+
+We pushed it to the running shell and looked at the Split view.
+
+![Split view showing a working toggle in the right pane and an empty left pane](no-image-here-this-is-prose)
+
+**The left pane was empty.** Or — more precisely — PTM was mounted, its
+status bar showed at top, but the body had hidden itself because the
+shared mode was `'pack'`. Pack Runner on the right showed its full UI.
+Two slots, one empty, one full. The icon-switcher worked perfectly,
+flipping a single piece of localStorage state that the *other* pane
+also read — but the shell still treated the pair as a co-existence
+pair. It mounted both remotes side-by-side; one just rendered nothing.
+
+We had built a feature inside the wrong scope. The toggle pretended to
+be a mode switch, but the architecture remained a co-existence split.
+
+### Phase 2c — the architectural fix
+
+The user called the question directly: *"is this a nested remote, or
+a shared UI component?"* It was both, but neither answered by itself.
+
+We laid out three options:
+
+| Option | Shape | Verdict |
+|---|---|---|
+| **A** | New federated `enrichmentSurface` wrapper remote that mounts PTM or Pack Runner internally | Clean but adds a federation hop and a new module to maintain |
+| **B** | Just a shared-UI toggle component used by both remotes | Doesn't solve the side-by-side problem; the shell still mounts both as a pair |
+| **C** | The shell learns about a "composite slot" — one slot that hosts one-of-N remotes based on shared state. The shared-UI toggle becomes the slot's header. | ✅ smallest correct change |
+
+We picked C, and that turned out to be the **same architectural
+question the plan had flagged as a spike** ("enrichment-surface
+composition — wrapper remote vs shared-state"). The act of trying to
+ship the wrong shape made the right shape visible. So we resolved the
+spike inside Phase 2c instead of waiting on a separate investigation.
+
+Here's the concept, in code:
+
+```ts
+// shell/src/composites.ts (NEW)
+export const ENRICHMENT_COMPOSITE: CompositeEntry = {
+  id: 'enrichment',
+  kind: 'composite',
+  label: 'Enrichment',
+  description: 'Author a custom prompt OR fire a pre-built pack against the record set',
+  modeKey: 'augment-it:enrichment-mode',
+  members: [
+    { remoteId: 'promptTemplateManager', icon: '✎', label: 'Custom prompt — author a free-text LLM prompt' },
+    { remoteId: 'packRunner', icon: '⊞', label: 'Pre-built pack — fire a source-bound pack against the record set' },
+  ],
+  defaultMemberId: 'packRunner',
+};
+```
+
+A `PAIRING` half can now reference either a remote id (the common case)
+or a composite id. The shell's `slotById()` resolves either kind:
+
+```ts
+// shell/src/remotes.ts
+export type Slot =
+  | { kind: 'remote'; remote: RemoteEntry }
+  | { kind: 'composite'; composite: CompositeEntry };
+
+export function slotById(id: string): Slot | undefined { /* ... */ }
+```
+
+And the rendering: when the materialized stage item carries a
+composite, the shell renders the shared toggle header above the mount.
+The shared-UI component (`packages/shared-ui/src/ToggleHeader__PromptOrPackage--Icons.svelte`)
+is pure presentation — receives `{ members, activeId, onSelect }` and
+owns no state of its own. The shell owns the mode; the toggle
+component owns the pixels.
+
+The two former pairings `recordCollector+promptTemplateManager` and
+`packRunner+promptTemplateManager` collapse into one:
+`recordCollector+enrichment`. PTM and Pack Runner lose their intra-
+remote mode-switch UI entirely — that revert is part of the same
+commit because the shell is now the single source of truth for the
+mode.
+
+### Phase 2d — make it work in every layout mode
+
+We reloaded the shell, flipped to Split, and the toggle worked beautifully.
+We flipped to Flow, walked into the enrichment slot... and the toggle
+was absent. PTM rendered as a normal rotation step. The composite was
+invisible in Flow mode.
+
+The user named the gap: *"this is a user-defined toggle so should work
+in both perspectives."*
+
+The fix required separating two concerns the shell had been conflating:
+
+1. **What federated remotes exist** (registry) — `REMOTES`
+2. **What slots are in the rotation** (order) — needed a new concept
+
+We introduced `ROTATION` as a peer to `REMOTES`:
+
+```ts
+// shell/src/remotes.ts
+export const ROTATION: string[] = [
+  'recordCollector',
+  'enrichment',          // composite — PTM ⇄ Pack Runner via in-slot toggle
+  'requestReviewer',
+  'responseReviewer',
+  'enhancedRecordsList',
+];
+```
+
+Everything that walks the rotation — peek-flow, full mode,
+`commitFocus`, the `augment-it:navigate` handler, even
+`layout.setFocusIndex`'s clamping — switched to iterate `ROTATION` via
+`slotById`. `REMOTES` stays as the federated-registry that
+`remoteById()` consults.
+
+The Composite slot now appears as a first-class rotation step in
+every layout mode. In Flow, it carries the ✎/⊞ toggle at the top of
+the focused slice. In Split, same toggle on the right of Record
+Collector. In Full, same toggle when you've drilled into the Enrichment
+step.
+
+One more subtlety: `MountHost` only runs its dynamic import in
+`onMount` — so when the user flips the toggle, the existing MountHost
+sees a new `remote` prop but its already-mounted member doesn't
+unmount. The fix is a Svelte `{#key}` block around the mount so the
+toggle change forces a re-mount cleanly:
+
+```svelte
+{#if item.composite}
+  <ToggleHeader ... />
+  {#key activeMembers[item.composite.id]}
+    <MountHost remote={item.remote} />
+  {/key}
+{:else}
+  <MountHost remote={item.remote} />
+{/if}
+```
+
+## Under the Hood
+
+### The audience cascade the refactor enables
+
+Phase 2's whole point is that the **enrichment surface is now one slot,
+not two.** The user's mental model has always been "I picked a record
+set; now augment it." The previous architecture forced them to pick
+which authoring flavor *and* which pane to look at. The composite
+slot collapses that into one decision (which member to toggle to) and
+keeps it portable across every layout mode.
+
+This is the same impulse that drove the spec's Decision §4 ("Augment
+This Set" — a set-level action in Record Collector that lands you on
+the enrichment slot pre-loaded) and Decision §8 (the hierarchical Flow
+widget with numbered bubble progress, where Enrichment is *one bubble*
+rather than two adjacent ones). Phase 2c+2d cleared the runway for
+both of those follow-on phases by establishing that **composites are
+the rotation unit** for enrichment.
+
+### Phase 2b was right to ship and right to revert
+
+It's tempting to call Phase 2b a mistake, but it wasn't. It shipped the
+visible behavior (the icon-switcher pattern, the off-mode hide rule, the
+shared-state mechanism) and it surfaced the architectural fork in the
+most useful way possible — by trying it. The plan had flagged the spike
+as "enrichment composition: wrapper remote vs shared-state" and slated
+a separate investigation. Phase 2b *was* the investigation, just
+disguised as an implementation. We commit-revert as a deliberate part
+of the journey, not as a "we got it wrong" footnote — the revert lives
+in the same commit as the Phase 2c work, with all the diff context
+visible for anyone retracing the steps.
+
+### The plan document tracks the journey
+
+`context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md`
+carries an acceptance log with each phase's status and the commit SHA
+that landed it. It's at semantic version `0.0.0.3` after this drop —
+v1 was the initial draft, v2 swapped Phase 2a (pack-selection helpers
+on a flat list) for the bundle-first Phase 3 once we reconciled
+against [[Packs-and-Bundles-Pattern]], v3 added Phase 2d after the
+in-browser eyeball revealed the rotation problem.
+
+If you want the full reasoning trail, the plan reads as the story of
+the refactor; the spec reads as the source of decisions; this changelog
+reads as the public-facing arc.
+
+## Files Touched
+
+**Plan & docs (NEW or substantive)**
+- `context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md` —
+  Phase 0 plan; updated through v0.0.0.3 with the spike resolution.
+
+**Shell (the core of the change)**
+- `shell/src/composites.ts` *(NEW)* — `CompositeEntry` type,
+  `ENRICHMENT_COMPOSITE`, read/write/broadcast helpers.
+- `shell/src/remotes.ts` — added `ROTATION`, `Slot` union, `slotById()`;
+  collapsed three former PAIRINGS into one (`recordCollector+enrichment`).
+- `shell/src/layout.svelte.ts` — `LayoutMode` literal `peek-deck` →
+  `peek-flow`; one-time migration; clamping switched to `ROTATION.length`.
+- `shell/src/App.svelte` — composite-aware stage builder, navigate
+  handler, peek-label rendering, `{#key}` re-mount for composite
+  toggles, peek labels anchored left.
+- `shell/package.json` — `@augment-it/shared-ui` workspace dependency.
+
+**Shared UI (NEW component)**
+- `packages/shared-ui/src/ToggleHeader__PromptOrPackage--Icons.svelte` —
+  pure-presentation icon-with-tooltip pair.
+- `packages/shared-ui/package.json` — export.
+
+**Remotes (revert of intra-remote mode UI)**
+- `apps/prompt-template-manager/src/App.svelte`,
+  `apps/prompt-template-manager/src/app.css` — removed mode-switcher
+  block, EnrichmentMode state, body wrapper, and `.ptm-mode` CSS.
+- `apps/pack-runner/src/App.svelte`, `apps/pack-runner/src/app.css` —
+  symmetric revert.
+
+## What's Next?
+
+Phase 3 — **bundle-first Pack Runner**. The spec's Decision §1 ("keep
+multi-select, add `none`/`solo`/`all` helpers") was conservative on
+purpose, but reconciling against [[../blueprints/Packs-and-Bundles-Pattern]]
+showed that polishing a flat 7-pack list cements a model the blueprint
+says is wrong. Phase 3 introduces **Bundle** as the primary selector in
+Pack Runner with two v1 bundles (`profile-builder` and
+`profile-builder.nonprofit`), and lets `all` / `none` / `solo` become
+roster-override helpers *inside* the chosen bundle — where they're
+conceptually correct. `pack.fan_out` will accept an optional `bundle_id`
+that lands on every ResponseRecord.
+
+Phase 4 — the hierarchical **Flow widget** that replaces the flat
+mode segment. Tier 1: the word "Flow" as parent. Tier 2: a numbered
+bubble progress strip derived from `ROTATION` (now meaningful because
+`enrichment` is one bubble, not two adjacent ones). Tier 3: Split /
+Full as small icon-with-tooltip toggles beneath Flow — reusing the
+exact pattern we just landed.
+
+Phase 5 — **"Augment This Set"** in Record Collector, landing the user
+on the Enrichment composite with the right record set pre-selected.
+
+## Related
+
+- [[../specs/Shell-and-Micro-Frontend-UX-Coherence]] — the audit spec
+  with the eight locked decisions and the three failure shapes
+- [[../plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor]] — the
+  six-phase plan that this shipment closes Phases 0–2 of
+- [[../blueprints/Packs-and-Bundles-Pattern]] — what Phase 3 will honor
+- [[2026-06-01_02_Shell-UX-Coherence-Spec-Drop]] — earlier today's
+  spec-drop changelog
+- [[../plans/Run-as-First-Class-Operation]] — Part 4 (live progress + nav
+  button) is adjacent to this work and still pending

--- a/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
+++ b/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
@@ -1,0 +1,414 @@
+---
+title: "Shell & Micro-Frontend UX Coherence — Refactor Plan"
+lede: "Sequence the eight locked decisions from the UX Coherence spec into five phases that land on `refactor/ux-streamlining`. Foundation first (Deck→Flow rename so every later phase speaks the right vocabulary), then mechanical polish that's independently shippable (peek labels, pack-selection helpers, off-mode hide), then the hierarchical Flow widget (bubble progress strip + icon-tooltip layout sub-options), then 'Augment This Set' with the record-set pre-selection unification, then harvest the cross-cutting principles into a living doc. Architectural open questions (enrichment-surface composition, Flow-widget default position) are spiked but not allowed to block the visible UX wins."
+date_created: 2026-06-01
+date_modified: 2026-06-01
+authors:
+  - Michael Staton
+augmented_with:
+  - Claude Code on Claude Opus 4.7
+semantic_version: 0.0.0.2
+revisions:
+  - 2026-06-01 — Initial draft (0.0.0.1).
+  - 2026-06-01 — Replaced Phase 2a's "none/solo/all helpers on flat pack
+    list" with a new Phase 3 — **bundle-first Pack Runner**. The original
+    spec Decision §1 was conservative on purpose, but reconciling against
+    [[../blueprints/Packs-and-Bundles-Pattern]] showed that polishing the
+    flat-list model would cement the wrong mental model right before the
+    bundle migration. Better to introduce Bundle as the primary selector
+    now and let `none`/`solo`/`all` become roster-override helpers on a
+    bundle's pack roster, where they belong. Subsequent phases renumbered.
+tags:
+  - Plan
+  - Augment-It
+  - Shell
+  - Micro-Frontends
+  - Refactor
+  - UX
+  - Flow-Widget
+  - Discoverability
+status: Draft
+---
+
+# Shell & Micro-Frontend UX Coherence — Refactor Plan
+
+## Source of record
+
+[[../specs/Shell-and-Micro-Frontend-UX-Coherence]] — eight decisions locked
+(2026-05-28 / 2026-06-01), cross-cutting principles seeded, per-surface
+audit partial. This plan is the *execution sequence* for those decisions
+on a single refactor branch.
+
+## Branch
+
+**`refactor/ux-streamlining`**, cut from the current tip of
+`feature/packs-and-bundles` (= `rebuild/turbo-rsbuild`, parity restored
+2026-06-01 at `5c7efb2`). PR target: `feature/packs-and-bundles` per the
+three-tier model (`development → main → master`).
+
+## Sequencing rationale
+
+The eight decisions are not peers. Three buckets:
+
+- **Vocabulary foundation** (§7 rename). Every subsequent phase references
+  "Flow"; do the rename first so we don't bake the wrong noun into a new
+  widget. Pure mechanical change, low risk, big legibility payoff.
+- **Mechanical polish** (§1, §5-surface, §6). Independently shippable
+  one-to-three-file changes. Visible wins early; reviewer confidence
+  builds before the structural phase.
+- **Structural** (§4, §5-composition, §8). New chrome (Flow widget +
+  bubble strip), new set-level action wired through localStorage
+  unification, and the open composition question for the enrichment
+  surface. These deserve their own commits and possibly their own
+  follow-up PR if §5-composition turns into a real spike.
+
+§3 (live progress + nav button) is already in flight via
+[[Run-as-First-Class-Operation]] Part 4 — referenced, not duplicated here.
+§2 (defaults parked) and the Open-questions list stay parked.
+
+## Phases
+
+### Phase 0 — Branch + scope confirmation
+
+- Cut `refactor/ux-streamlining` from current tip.
+- Re-read the spec's Decisions §1–§8 with the user, confirm nothing has
+  shifted since 2026-06-01.
+- Stub this plan's acceptance log (per-phase ✅/⏳).
+
+**Acceptance:** branch exists, plan committed, no code changes yet.
+
+---
+
+### Phase 1 — Deck → Flow rename (Decision §7)
+
+Foundation. Touches a small, contained surface.
+
+**Files:**
+- `shell/src/App.svelte` — UI label at line ~199; comments at ~66, 103, 112.
+- `shell/src/layout.svelte.ts` — `LayoutMode` literal `'peek-deck'` →
+  `'peek-flow'` (line 15); default at 28; `defaultMode` at 32; comments
+  at 6, 19, 20, 99.
+- `shell/src/remotes.ts` — comments at 73, 85.
+- Repo-wide grep for `peek-deck`, `Deck`, `deck` in shell/remote source
+  and CSS to catch stragglers.
+
+**Migration concern (locked in spec):** the persisted `STORAGE_KEY =
+'augment-it:shell-layout'` JSON has `mode: 'peek-deck'`. On read,
+translate `'peek-deck'` → `'peek-flow'` once, then write. One-line
+defensive map in `readStored()`.
+
+**Acceptance:**
+- All visible "Deck" copy says "Flow".
+- `pnpm build` + dev-loop smoke passes.
+- Existing localStorage from before the rename still loads.
+
+---
+
+### Phase 2 — Mechanical polish (Decisions §5-surface, §6)
+
+Two independent commits, parallelizable. (Decision §1 pack-selection
+was pulled out into Phase 3 — see rationale below.)
+
+#### 2a. Peek-deck position labels anchor left (Decision §6)
+
+`shell/src/App.svelte` — `.peek-overlay { justify-content: center }` →
+`flex-start`. Revisit `padding-top: 1.5rem`.
+
+**Open implementation detail (flag at build time):** left-side vs
+right-side peek neighbours — outer-left edge for both, or inner-edge?
+Default to outer-left edge of the slice (label hugs the shell's outside
+boundary); confirm by eye.
+
+**Acceptance:** every peek-pane position label sits at the slice's left
+margin, doesn't float center.
+
+#### 2b. Enrichment-mode exclusive UI — icon-switcher surface only (Decision §5, surface portion)
+
+`apps/prompt-template-manager/src/App.svelte` and
+`apps/pack-runner/src/App.svelte`.
+
+- Replace the verbose mode-tab buttons at the top of each pane with
+  a small **icon-with-tooltip pair** (one icon for "custom prompt", one
+  for "pre-built pack").
+- Hide the off-mode body. PTM's PROMPTS list + NEW PROMPT form do not
+  render when Pack Runner is the active mode, and vice versa. Read the
+  shared mode from the existing `augment-it:enrichment-mode` event +
+  localStorage — that's the smaller-change "option (b)" path.
+
+**Deferring** the open question of wrapper-remote vs shared-state
+composition to the spike (see below). Phase 2b gets the visible
+behaviour with option (b)'s mechanics; if the spike picks option (a),
+the icon switcher and hide-rule survive the refactor unchanged.
+
+**Acceptance:** picking "pre-built pack" leaves only Pack Runner's body
+visible; picking "custom prompt" leaves only PTM's. Icon switcher
+present on both panes with consistent tooltips.
+
+---
+
+### Phase 3 — Bundle-first Pack Runner (supersedes spec Decision §1)
+
+**Why this replaces Decision §1's helpers.** The spec was "conservative
+on purpose" — keep the multi-select flat-pack-list and add `none`/`solo`/
+`all`. But [[../blueprints/Packs-and-Bundles-Pattern]] says the
+orchestration unit is a **bundle** — a named composition with 4-6 default
+packs + opt-in extras, one chat verb per bundle, `bundle_id` on every
+ResponseRecord. Today's Pack Runner (`apps/pack-runner/src/App.svelte:8-15`)
+is a hardcoded list of 7 packs with no bundle anywhere in the model.
+Polishing the flat list with helpers cements a model the blueprint says
+is wrong. Better to introduce bundles now and let the helpers (`all` /
+`none` / `solo`) become **roster-override** affordances *inside* a
+bundle's pack panel, where they're conceptually correct.
+
+#### Scope discipline — what's IN this phase, what's deferred
+
+**IN this phase** (the minimum to make Bundle the primary selector):
+
+1. **Shared bundle registry** as a TS module both Pack Runner and the
+   social-search service can import. v1 location: `packages/bundles/`
+   (graduates toward independent publication, per `ai-labs/packages/`
+   convention) — or `services/social-search/src/bundles.ts` alongside
+   `packs.ts` if a shared package is overkill for v1. Pick the smaller
+   on day one; a v1 with one file lives in the service.
+2. **Two bundles for v1**:
+   - `profile-builder` — common five (LinkedIn, X, BlueSky, YouTube,
+     Wikipedia) all `default: true`; Facebook + Instagram opt-in.
+     Single-pass.
+   - `profile-builder.nonprofit` — same common five + Wikipedia
+     `default: true`; opt-in for the nonprofit-specific packs once
+     they exist. Stub the entity-type plumbing even if the extra
+     packs aren't built yet.
+3. **Pack Runner UI**:
+   - **Primary selector** — segmented control (or dropdown) of available
+     bundles at the top of the Pack Runner pane. One selected at a time.
+   - **Roster panel** — beneath the selector, the bundle's roster
+     renders with `default: true` packs pre-checked. `default: false`
+     packs render but unchecked. This is where the `all` / `none` /
+     `solo` helpers from spec Decision §1 land — they operate on the
+     **current bundle's roster**, not on a universe of all packs.
+   - **Fire button copy** — `Fire <bundle.display_name>` on N rows,
+     subline `K packs × N rows · K·N fetches`. (Honors blueprint
+     §"Records, not cells, are the unit of intent.")
+4. **Fire path**:
+   - Pack Runner derives effective `pack_ids` = bundle's roster filtered
+     by roster-overrides.
+   - Calls `pack.fan_out` (existing verb) with `pack_ids` AND a new
+     `bundle_id` parameter.
+   - `pack.fan_out` writes `bundle_id` onto every ResponseRecord it
+     produces. ResponseRecord type already declares `bundle_id?: string`
+     per the blueprint — verify and wire.
+5. **localStorage**:
+   - Persist active bundle id under `augment-it:pack-runner:bundle-id`.
+   - Persist per-bundle roster overrides as
+     `augment-it:pack-runner:roster-overrides:<bundle_id>` so swapping
+     bundles doesn't lose user tuning per bundle.
+
+**DEFERRED to a follow-up plan** (these are bundle features the
+blueprint defines but this refactor doesn't need to ship):
+
+- Two-pass orchestration with data carry-forward between passes
+  (blueprint §Bundle anatomy).
+- Pre-flight `profiles.dedup.scan` (blueprint §"Every bundle invokes").
+- `bundle-level render strategy` for per-row, per-bundle aggregate views.
+- The chat verb registration (`profile-builder` as a one-shot chat verb)
+  — that's [[In-App-Chat-v0-0-1-for-Augment-It]]'s problem.
+- `pass: 1 | 2` per-pack roster fields beyond the data-model wiring.
+
+#### Files touched (estimated)
+
+- **NEW** `services/social-search/src/bundles.ts` — bundle registry + the
+  two v1 bundles.
+- `services/social-search/src/packs.ts` (or wherever `pack.fan_out` is
+  implemented) — accept `bundle_id` arg; write to ResponseRecord on
+  emit.
+- `apps/pack-runner/src/App.svelte` — replace flat PACKS list with
+  bundle selector + roster panel; relocate `none`/`solo`/`all` helpers
+  into roster panel; new localStorage keys; fire button copy.
+- ResponseRecord type definition (wherever it lives) — confirm
+  `bundle_id?: string` is declared and threaded.
+
+#### Risk register for Phase 3
+
+- **`pack.fan_out` shape change.** Mitigation: `bundle_id` is optional
+  on the input; old call sites (if any besides Pack Runner) still work.
+- **Migration from flat-list localStorage state.** Mitigation: on first
+  load, if no bundle is selected and the old `enabledPackIds` storage
+  exists, pick `profile-builder` as default; ignore the old key.
+- **The "Augment This Set" landing (Phase 5) assumes Pack Runner opens
+  ready-to-fire.** Mitigation: Phase 3 ships the default-bundle auto-
+  selection (`profile-builder` if no last-used bundle), so Phase 5's
+  landing path works.
+
+**Acceptance:**
+- Pack Runner shows a bundle selector with two bundles.
+- Picking a bundle reveals its roster with correct defaults.
+- `all`/`none`/`solo` work as roster-overrides within the selected bundle.
+- Fire writes `bundle_id` to every ResponseRecord produced.
+- Bundle choice + roster overrides persist per bundle across reloads.
+
+---
+
+### Phase 4 — Hierarchical Flow widget (Decision §8)
+
+The biggest chrome change. New component, replaces the flat
+`ModeToggle`-style segment with a three-tier widget.
+
+**New component:** `shell/src/FlowWidget.svelte` (or extend
+`ModeToggle.svelte` — decide by size; new file if the tier-2 strip is
+non-trivial).
+
+**Tiers:**
+1. The word **Flow**, raised — visual parent.
+2. **Bubble progress strip** — `REMOTES.map((r, i) => bubble(i, r.label, r.description))`.
+   Active step = `layout.focusIndex`. Click a bubble = dispatch
+   `augment-it:navigate` with `{ remoteId: REMOTES[i].id }`. Tooltip body
+   from `REMOTES[i].description`.
+3. **Split / Full** as small icon-with-tooltip toggles (same affordance
+   pattern as Phase 2c).
+
+**Position-toggle:** swap widget between top (horizontal bubble row,
+current location) and left-hand column (vertical bubble row). Persist
+the choice in `ShellLayout` as a new field (`flowWidgetPosition: 'top'
+| 'left'`). **Default: `'top'`** (minimal layout disruption — argued
+in spec Open questions).
+
+**Coherence with Phase 2a:** when `flowWidgetPosition === 'left'`,
+the left-anchored peek labels collapse into the rail (same information
+twice is silly). Either suppress `.peek-overlay` rendering in left
+mode, or visually merge.
+
+**Open question pinned at build time:** the `REMOTES` rotation has
+`promptTemplateManager` as a discrete step. With Decision §5 unifying
+PTM ⇄ Pack Runner, should the strip render **one "Enrichment" bubble**
+covering both, or two? Spec leans "one." Implementation: a small
+`flowSteps` projection over `REMOTES` that collapses adjacent
+PTM+packRunner entries into a single virtual step. Default to one.
+
+**Acceptance:**
+- Flow widget renders with parent label, bubble strip, Split/Full
+  icon toggles.
+- Bubble click navigates; tooltip reveals step name.
+- Active bubble highlights from `focusIndex`.
+- Position toggle works; persists.
+- Left-column mode does not double-render peek labels.
+
+---
+
+### Phase 5 — "Augment This Set" + record-set pre-selection unification (Decision §4)
+
+`apps/record-collector/src/App.svelte` — add the set-level button next
+to (not replacing) the per-row `enrich ›`.
+
+**Mechanic locked in spec:**
+- Set the active record set in localStorage (key TBD — see implementation
+  detail below) **before** dispatching nav.
+- Dispatch `augment-it:navigate` with `{ remoteId: 'packRunner' }`.
+- `packRunner` isn't in `REMOTES` rotation → shell's nav handler falls
+  through to PAIRINGS → `layout.openPair('packRunner+promptTemplateManager')`.
+
+**Implementation detail to resolve in this phase:** Pack Runner reads
+`localStorage['augment-it:pack-runner:record-set']`; Prompt Template
+Manager has its own key. **Unify** to a single shared key
+(`'augment-it:active-record-set'` is a reasonable name) that both
+remotes read, with one-time backward-read of each remote's old key for
+migration. This is the prerequisite for Decision §4's "one write
+pre-selects both."
+
+**Acceptance:**
+- "Augment This Set" button visible once a record set is selected in
+  Record Collector.
+- Click opens the PTM ⇄ Pack Runner split with the chosen record set
+  pre-loaded on both sides.
+- Existing per-row `enrich ›` continues to work unchanged.
+
+---
+
+### Phase 6 — Cross-cutting principles + per-surface audit harvest
+
+Write up the cross-cutting principles section that the spec seeded but
+left as a TBD comment. Promote from "candidates" to a stable list once
+the phases above have proven them in code. Likely landing place: a
+small companion doc `context-v/blueprints/Shell-UX-Coherence-Principles.md`
+the spec links to, or appended to the spec's §Cross-cutting principles.
+
+Also: fill in the four `needs-audit` surfaces (Request Reviewer, Chat,
+Shell-rest, Enhanced-Records-promote-flow) with whatever this refactor
+surfaced about them.
+
+**Acceptance:** principles list exists as a stable doc; per-surface
+audit table has no remaining `needs-audit` rows OR the remaining ones
+have explicit "deferred to spec X" notes.
+
+---
+
+## Architectural spike (parallel to Phase 4, gate before Phase 5 final commit)
+
+**Enrichment-surface composition (Decision §5 open question):**
+should PTM + Pack Runner be wrapped in a single `enrichmentSurface`
+parent remote, or stay separate remotes sharing mode state via the
+existing window event?
+
+Argument for **(a) wrapper remote**: cleaner conceptual unit; the
+Flow widget's "one Enrichment bubble" question (Phase 3) answers
+itself; one tile owns the icon switcher.
+
+Argument for **(b) shared-state**: smaller change; preserves the
+existing pairing; Phase 2c already works with this shape.
+
+**Spike output:** a one-pager appended to this plan (or a child
+context-v note) recommending (a) or (b), with an estimated
+file-touch surface. **Gate:** don't ship Phase 5's final commit until
+this resolves, because "Augment This Set"'s target — `packRunner` vs
+a new `enrichmentSurface` remote — depends on it.
+
+---
+
+## Risk register
+
+- **Deck→Flow localStorage migration (Phase 1).** Mitigation: one-line
+  defensive map in `readStored()`. Test by hand-editing the stored
+  JSON before launch.
+- **Bubble click → navigate semantics (Phase 3).** `augment-it:navigate`
+  is the existing primitive; if a remote doesn't handle it cleanly
+  the click silently fails (a Dead-shape failure per the spec's own
+  taxonomy — ironic). Mitigation: verify each `REMOTES[i].id` resolves
+  to a registered handler before wiring the click.
+- **Phase 4 left-column position-toggle interacts with Phase 2a peek
+  labels.** Mitigation: build the toggle last within Phase 4 and pair
+  with the peek-label rendering rule explicitly.
+- **Phase 5 record-set key unification breaks in-flight runs.**
+  Mitigation: read both old keys, write the new key, keep writing the
+  old keys for one release; remove old-key writes in a follow-up PR.
+
+## Out of scope (parked)
+
+- Entity-name foot-gun warning (spec §2, Open questions).
+- Default-scope nudge for first run (spec §2, Open questions).
+- API-First In-App Documentation (spec Wish list, stubbed separately).
+- Augment-it's dual-identity blueprint (stubbed separately).
+- Initial-User-Experience spec (stubbed separately).
+- Auth-Patterns blueprint (stubbed separately).
+
+## Acceptance log
+
+| Phase | Status | Branch tip | Notes |
+|---|---|---|---|
+| 0 — Branch + plan | ⏳ | — | this commit |
+| 1 — Deck→Flow rename | ⏳ | — | |
+| 2a — Peek labels anchor left | ⏳ | — | |
+| 2b — Enrichment-mode exclusive UI | ⏳ | — | |
+| 3 — Bundle-first Pack Runner | ⏳ | — | supersedes spec §1 helpers |
+| 4 — Flow widget | ⏳ | — | |
+| 5 — Augment This Set + key unification | ⏳ | — | gated on spike |
+| 6 — Principles + audit harvest | ⏳ | — | |
+| Spike — enrichment composition | ⏳ | — | gates Phase 5 |
+
+## Related
+
+- [[../specs/Shell-and-Micro-Frontend-UX-Coherence]] — source of record
+- [[Run-as-First-Class-Operation]] — owns §3 (live progress + nav)
+- [[../blueprints/Module-Federation-Rsbuild-Dev-Loop-Gotchas]] — shell
+  federation mechanics this refactor builds on
+- [[../blueprints/Packs-and-Bundles-Pattern]] — Triage Surface UX
+  Requirements section sits adjacent to Phase 2a
+- [[../reminders/Pickup-2026-06-01]] — session-resume notes

--- a/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
+++ b/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
@@ -18,6 +18,13 @@ revisions:
     bundle migration. Better to introduce Bundle as the primary selector
     now and let `none`/`solo`/`all` become roster-override helpers on a
     bundle's pack roster, where they belong. Subsequent phases renumbered.
+  - 2026-06-01 — Added Phase 2d: the user landed on the Phase 2c result in
+    Split mode and observed the toggle only worked there — Flow mode walked
+    `REMOTES`, which composites weren't part of. Introduced `ROTATION: string[]`
+    as a peer to `REMOTES` (rotation order of slot ids, including composite
+    ids) and switched peek-flow / full / `commitFocus` / nav-handler /
+    `layout.setFocusIndex` clamping to walk `ROTATION` via `slotById`.
+    Composites are now first-class in every layout mode.
   - 2026-06-01 — **Spike resolved: Option C — composite slot in the shell
     + shared toggle component.** Trying Phase 2b's intra-remote off-mode-
     hide in the browser made the architectural error visible — both
@@ -410,7 +417,8 @@ a new `enrichmentSurface` remote — depends on it.
 | 1 — Deck→Flow rename | ⏳ | — | |
 | 2a — Peek labels anchor left | ⏳ | — | |
 | 2b — Enrichment-mode exclusive UI (intra-remote) | ✅→↩ | 62731fd | superseded by 2c |
-| 2c — Composite slot + shared toggle | ⏳ | — | resolves the spike |
+| 2c — Composite slot + shared toggle | ✅ | b9b99df | resolves the spike |
+| 2d — Composites are peers in Flow rotation | ⏳ | — | ROTATION peer to REMOTES; in-slot toggle works in Flow & Full too |
 | 3 — Bundle-first Pack Runner | ⏳ | — | supersedes spec §1 helpers |
 | 4 — Flow widget | ⏳ | — | |
 | 5 — Augment This Set + key unification | ⏳ | — | gated on spike |

--- a/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
+++ b/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
@@ -7,7 +7,7 @@ authors:
   - Michael Staton
 augmented_with:
   - Claude Code on Claude Opus 4.7
-semantic_version: 0.0.0.2
+semantic_version: 0.0.0.3
 revisions:
   - 2026-06-01 — Initial draft (0.0.0.1).
   - 2026-06-01 — Replaced Phase 2a's "none/solo/all helpers on flat pack
@@ -18,6 +18,19 @@ revisions:
     bundle migration. Better to introduce Bundle as the primary selector
     now and let `none`/`solo`/`all` become roster-override helpers on a
     bundle's pack roster, where they belong. Subsequent phases renumbered.
+  - 2026-06-01 — **Spike resolved: Option C — composite slot in the shell
+    + shared toggle component.** Trying Phase 2b's intra-remote off-mode-
+    hide in the browser made the architectural error visible — both
+    remotes stayed mounted side-by-side; one just rendered empty. The
+    correct shape is one slot in the shell that hosts one-of-N remotes
+    based on shared state. Phase 2b is superseded by a new Phase 2c that
+    (a) reverts the intra-remote mode UI in PTM and Pack Runner,
+    (b) introduces a `CompositeEntry` concept in the shell,
+    (c) adds a shared-ui `ToggleHeader__PromptOrPackage--Icons.svelte`,
+    (d) defines `ENRICHMENT_COMPOSITE` ({ PTM, Pack Runner }) and a
+    `recordCollector+enrichment` pairing that replaces the now-obsolete
+    `packRunner+promptTemplateManager` and `recordCollector+promptTemplateManager`
+    pairings. The spike no longer gates Phase 5.
 tags:
   - Plan
   - Augment-It
@@ -396,12 +409,13 @@ a new `enrichmentSurface` remote — depends on it.
 | 0 — Branch + plan | ⏳ | — | this commit |
 | 1 — Deck→Flow rename | ⏳ | — | |
 | 2a — Peek labels anchor left | ⏳ | — | |
-| 2b — Enrichment-mode exclusive UI | ⏳ | — | |
+| 2b — Enrichment-mode exclusive UI (intra-remote) | ✅→↩ | 62731fd | superseded by 2c |
+| 2c — Composite slot + shared toggle | ⏳ | — | resolves the spike |
 | 3 — Bundle-first Pack Runner | ⏳ | — | supersedes spec §1 helpers |
 | 4 — Flow widget | ⏳ | — | |
 | 5 — Augment This Set + key unification | ⏳ | — | gated on spike |
 | 6 — Principles + audit harvest | ⏳ | — | |
-| Spike — enrichment composition | ⏳ | — | gates Phase 5 |
+| Spike — enrichment composition | ✅ | — | resolved as Option C (composite slot), Phase 2c is the landing |
 
 ## Related
 

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "exports": {
-    "./ConfidencePill.svelte": "./src/ConfidencePill.svelte"
+    "./ConfidencePill.svelte": "./src/ConfidencePill.svelte",
+    "./ToggleHeader__PromptOrPackage--Icons.svelte": "./src/ToggleHeader__PromptOrPackage--Icons.svelte"
   },
   "peerDependencies": {
     "svelte": "^5.0.0"

--- a/packages/shared-ui/src/ToggleHeader__PromptOrPackage--Icons.svelte
+++ b/packages/shared-ui/src/ToggleHeader__PromptOrPackage--Icons.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+  /**
+   * Composite-slot header for the enrichment surface.
+   *
+   * Renders an icon-with-tooltip pair that swaps which member remote the
+   * shell's composite slot mounts (Prompt Templates ✎ vs Pack Runner ⊞).
+   * The shell owns the "which slot, which member" decision — this component
+   * is pure presentation; it reads/writes the active member via a
+   * caller-provided callback and reacts to changes via props.
+   *
+   * Spec: context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md §5
+   * Plan: context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md §2c
+   */
+
+  type Member = {
+    id: string;
+    icon: string;
+    label: string;
+  };
+
+  let {
+    members,
+    activeId,
+    onSelect,
+  }: {
+    members: Member[];
+    activeId: string;
+    onSelect: (memberId: string) => void;
+  } = $props();
+</script>
+
+<div class="toggle-header" role="tablist" aria-label="Enrichment mode">
+  {#each members as m (m.id)}
+    <button
+      class="toggle"
+      class:active={m.id === activeId}
+      role="tab"
+      aria-selected={m.id === activeId}
+      aria-label={m.label}
+      title={m.label}
+      onclick={() => onSelect(m.id)}
+    >
+      <span aria-hidden="true">{m.icon}</span>
+    </button>
+  {/each}
+</div>
+
+<style>
+  .toggle-header {
+    display: flex;
+    gap: 0.4rem;
+    padding: 0.5rem 1.5rem;
+    border-bottom: 1px solid var(--color-border);
+    background: var(--color-background);
+  }
+  .toggle {
+    background: transparent;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+    width: 1.9rem;
+    height: 1.9rem;
+    padding: 0;
+    border-radius: 6px;
+    font-size: 1rem;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  }
+  .toggle:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+  .toggle.active {
+    background: var(--color-accent);
+    color: var(--color-on-accent);
+    border-color: var(--color-accent);
+    cursor: default;
+  }
+  .toggle.active:hover {
+    color: var(--color-on-accent);
+  }
+</style>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,9 @@ importers:
 
   shell:
     dependencies:
+      '@augment-it/shared-ui':
+        specifier: workspace:*
+        version: link:../packages/shared-ui
       '@augment-it/theme':
         specifier: workspace:*
         version: link:../packages/theme

--- a/shell/package.json
+++ b/shell/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@augment-it/workspace": "workspace:*",
     "@augment-it/theme": "workspace:*",
+    "@augment-it/shared-ui": "workspace:*",
     "svelte": "^5.0.0"
   },
   "devDependencies": {

--- a/shell/src/App.svelte
+++ b/shell/src/App.svelte
@@ -2,7 +2,23 @@
   import { onMount } from 'svelte';
   import ModeToggle from './ModeToggle.svelte';
   import MountHost from './MountHost.svelte';
-  import { REMOTES, PAIRINGS, CHAT_REMOTE, remoteById, type RemoteEntry } from './remotes';
+  import ToggleHeader from '@augment-it/shared-ui/ToggleHeader__PromptOrPackage--Icons.svelte';
+  import {
+    REMOTES,
+    PAIRINGS,
+    CHAT_REMOTE,
+    remoteById,
+    slotById,
+    type RemoteEntry,
+    type Slot,
+  } from './remotes';
+  import {
+    COMPOSITES,
+    readActiveMemberId,
+    writeActiveMemberId,
+    compositeFor,
+    type CompositeEntry,
+  } from './composites';
   import { layout, type LayoutMode } from './layout.svelte';
 
   // Chat rail visibility — persistent left-side companion to the focused
@@ -24,18 +40,56 @@
     }
   }
 
+  // ---- composite slots — active-member state ----------------------------
+  // A composite slot hosts one-of-N remotes based on shared state. We
+  // keep the active member id per composite as reactive state so the
+  // stage derived re-builds when the user clicks the in-slot toggle.
+  // The state is also published via the composite's modeKey window event,
+  // so external dispatchers (e.g. cross-remote augment-it:navigate) keep
+  // working.
+  let activeMembers = $state<Record<string, string>>(
+    Object.fromEntries(COMPOSITES.map((c) => [c.id, readActiveMemberId(c)])),
+  );
+
+  function setCompositeMember(c: CompositeEntry, memberId: string): void {
+    activeMembers = { ...activeMembers, [c.id]: memberId };
+    writeActiveMemberId(c, memberId);
+  }
+
   // ---- geometry constants -------------------------------------------------
   const HOVER_PCT = 38;       // a hovered peek neighbour expands to this width
   const MIN_PEEK = 4;         // a peek neighbour never narrower than this
 
   type StageRole = 'focused' | 'prev' | 'next' | 'pair-left' | 'pair-right' | 'full';
   type StageItem = {
-    id: string;
+    id: string;             // includes ':' + active-member id for composites so MountHost re-mounts on toggle
     remote: RemoteEntry;
     widthPct: number;
     zIndex: number;
     role: StageRole;
+    composite?: CompositeEntry;  // when set, render ToggleHeader above MountHost
   };
+
+  function materializeSlot(slot: Slot, widthPct: number, role: StageRole): StageItem | null {
+    if (slot.kind === 'remote') {
+      return { id: slot.remote.id, remote: slot.remote, widthPct, zIndex: 1, role };
+    }
+    const c = slot.composite;
+    const activeId = activeMembers[c.id] ?? c.defaultMemberId;
+    const remote = remoteById(activeId);
+    if (!remote) return null;
+    // Key the StageItem so toggling re-mounts MountHost (MountHost only
+    // runs its dynamic import in onMount; without a key change, swapping
+    // the `remote` prop would leak the previous member.)
+    return {
+      id: `${c.id}:${activeId}`,
+      remote,
+      widthPct,
+      zIndex: 1,
+      role,
+      composite: c,
+    };
+  }
 
   // ---- transient interaction state (never persisted) ----------------------
   let hoveredNeighborId = $state<string | null>(null);
@@ -53,14 +107,16 @@
     if (layout.mode === 'co-existence') {
       const pairing = PAIRINGS.find((p) => p.key === layout.activePairKey) ?? PAIRINGS[0];
       if (!pairing) return [];
-      const left = remoteById(pairing.left);
-      const right = remoteById(pairing.right);
-      if (!left || !right) return [];
+      const leftSlot = slotById(pairing.left);
+      const rightSlot = slotById(pairing.right);
+      if (!leftSlot || !rightSlot) return [];
       const leftPct = layout.ratioFor(pairing.key, pairing.defaultLeftPct);
-      return [
-        { id: left.id, remote: left, widthPct: leftPct, zIndex: 1, role: 'pair-left' },
-        { id: right.id, remote: right, widthPct: 100 - leftPct, zIndex: 1, role: 'pair-right' },
-      ];
+      const items: StageItem[] = [];
+      const l = materializeSlot(leftSlot, leftPct, 'pair-left');
+      const r = materializeSlot(rightSlot, 100 - leftPct, 'pair-right');
+      if (l) items.push(l);
+      if (r) items.push(r);
+      return items;
     }
 
     // peek-flow
@@ -181,9 +237,19 @@
         layout.setMode(detail.mode ?? 'full');
         return;
       }
-      // Not in the rotation — might be a "pair-only" remote like packRunner.
-      // If a PAIRING includes it, open the pair in co-existence mode so the
-      // user lands somewhere usable rather than nowhere.
+      // Might be a composite member (e.g. packRunner inside enrichment).
+      // Set the composite's active member to the requested remote, then
+      // open the pairing that contains the composite.
+      const composite = compositeFor(detail.remoteId);
+      if (composite) {
+        setCompositeMember(composite, detail.remoteId);
+        const pair = PAIRINGS.find(
+          (p) => p.left === composite.id || p.right === composite.id,
+        );
+        if (pair) layout.openPair(pair.key);
+        return;
+      }
+      // Otherwise — a "pair-only" remote referenced directly by a PAIRING.
       const pairing = PAIRINGS.find(
         (p) => p.left === detail.remoteId || p.right === detail.remoteId,
       );
@@ -192,7 +258,26 @@
       }
     };
     window.addEventListener('augment-it:navigate', onNavigate);
-    return () => window.removeEventListener('augment-it:navigate', onNavigate);
+
+    // Listen for external composite-mode broadcasts so peer surfaces that
+    // change a composite's active member (e.g. a future analytics overlay)
+    // stay in sync. Internal toggle clicks update activeMembers directly
+    // via setCompositeMember; this handler covers everything else.
+    const compositeListeners = COMPOSITES.map((c) => {
+      const handler = (ev: Event) => {
+        const d = (ev as CustomEvent).detail as { memberId?: string } | undefined;
+        if (d?.memberId && d.memberId !== activeMembers[c.id]) {
+          activeMembers = { ...activeMembers, [c.id]: d.memberId };
+        }
+      };
+      window.addEventListener(c.modeKey, handler);
+      return () => window.removeEventListener(c.modeKey, handler);
+    });
+
+    return () => {
+      window.removeEventListener('augment-it:navigate', onNavigate);
+      compositeListeners.forEach((off) => off());
+    };
   });
 
   const MODE_BUTTONS: { mode: LayoutMode; label: string }[] = [
@@ -254,8 +339,15 @@
   >
   {#each stage as item (item.id)}
     {@const isInteractive = item.role !== 'prev' && item.role !== 'next'}
-    <section class="slot" class:slot-peek={!isInteractive}
+    <section class="slot" class:slot-peek={!isInteractive} class:slot-composite={!!item.composite}
       style="width: {item.widthPct}%; z-index: {item.zIndex};">
+      {#if item.composite}
+        <ToggleHeader
+          members={item.composite.members.map((m) => ({ id: m.remoteId, icon: m.icon, label: m.label }))}
+          activeId={activeMembers[item.composite.id] ?? item.composite.defaultMemberId}
+          onSelect={(memberId) => setCompositeMember(item.composite!, memberId)}
+        />
+      {/if}
       <MountHost remote={item.remote} />
 
       {#if !isInteractive}
@@ -403,6 +495,17 @@
   /* the focused / interactive slot reads as raised */
   .slot:not(.slot-peek) {
     box-shadow: var(--fx-card-shadow);
+  }
+
+  /* Composite slots stack the toggle header above the mounted remote;
+     the MountHost takes the remaining vertical space (Phase 2c). */
+  .slot-composite {
+    display: flex;
+    flex-direction: column;
+  }
+  .slot-composite :global(.mount-host) {
+    flex: 1 1 auto;
+    min-height: 0;
   }
 
   /* peek neighbour click-capture overlay.

--- a/shell/src/App.svelte
+++ b/shell/src/App.svelte
@@ -4,7 +4,7 @@
   import MountHost from './MountHost.svelte';
   import ToggleHeader from '@augment-it/shared-ui/ToggleHeader__PromptOrPackage--Icons.svelte';
   import {
-    REMOTES,
+    ROTATION,
     PAIRINGS,
     CHAT_REMOTE,
     remoteById,
@@ -62,30 +62,36 @@
 
   type StageRole = 'focused' | 'prev' | 'next' | 'pair-left' | 'pair-right' | 'full';
   type StageItem = {
-    id: string;             // includes ':' + active-member id for composites so MountHost re-mounts on toggle
-    remote: RemoteEntry;
+    id: string;                  // ROTATION slot id (remote id or composite id); stable across composite toggles
+    remote: RemoteEntry;         // the active remote for this slot (resolved composite member, or the remote itself)
+    label: string;               // user-facing label — composite.label for composites, remote.label otherwise
     widthPct: number;
     zIndex: number;
     role: StageRole;
-    composite?: CompositeEntry;  // when set, render ToggleHeader above MountHost
+    composite?: CompositeEntry;  // when set, render ToggleHeader above MountHost and {#key} the mount on active-member changes
   };
 
-  function materializeSlot(slot: Slot, widthPct: number, role: StageRole): StageItem | null {
+  function materializeSlot(slot: Slot, widthPct: number, role: StageRole, zIndex = 1): StageItem | null {
     if (slot.kind === 'remote') {
-      return { id: slot.remote.id, remote: slot.remote, widthPct, zIndex: 1, role };
+      return {
+        id: slot.remote.id,
+        remote: slot.remote,
+        label: slot.remote.label,
+        widthPct,
+        zIndex,
+        role,
+      };
     }
     const c = slot.composite;
     const activeId = activeMembers[c.id] ?? c.defaultMemberId;
     const remote = remoteById(activeId);
     if (!remote) return null;
-    // Key the StageItem so toggling re-mounts MountHost (MountHost only
-    // runs its dynamic import in onMount; without a key change, swapping
-    // the `remote` prop would leak the previous member.)
     return {
-      id: `${c.id}:${activeId}`,
+      id: c.id,
       remote,
+      label: c.label,
       widthPct,
-      zIndex: 1,
+      zIndex,
       role,
       composite: c,
     };
@@ -98,10 +104,17 @@
   let splitting = $state<boolean>(false);
 
   // ---- the stage geometry — derived from layout + interaction -------------
+  // All three modes walk ROTATION (a list of slot ids) and resolve each id
+  // via slotById() — a slot can be a federated remote or a composite. The
+  // composite case keeps a ToggleHeader in the slot in every layout mode,
+  // so the in-slot toggle (e.g. enrichment's PTM⇄Pack-Runner pair) works
+  // in Flow, Split, and Full alike (Phase 2d).
   const stage = $derived.by<StageItem[]>(() => {
     if (layout.mode === 'full') {
-      const r = REMOTES[layout.focusIndex];
-      return r ? [{ id: r.id, remote: r, widthPct: 100, zIndex: 1, role: 'full' }] : [];
+      const slot = slotById(ROTATION[layout.focusIndex]);
+      if (!slot) return [];
+      const item = materializeSlot(slot, 100, 'full');
+      return item ? [item] : [];
     }
 
     if (layout.mode === 'co-existence') {
@@ -121,44 +134,48 @@
 
     // peek-flow
     const i = layout.focusIndex;
-    const focused = REMOTES[i];
-    if (!focused) return [];
-    const prev = REMOTES[i - 1];
-    const next = REMOTES[i + 1];
-    const neighbours = [prev, next].filter(Boolean) as RemoteEntry[];
+    const focusedSlot = slotById(ROTATION[i]);
+    if (!focusedSlot) return [];
+    const prevSlot = i > 0 ? slotById(ROTATION[i - 1]) : undefined;
+    const nextSlot = i < ROTATION.length - 1 ? slotById(ROTATION[i + 1]) : undefined;
+    const neighbourCount = (prevSlot ? 1 : 0) + (nextSlot ? 1 : 0);
     const remainder = 100 - layout.focusedWidthPct;
-    const peekEach = neighbours.length ? Math.max(MIN_PEEK, remainder / neighbours.length) : 0;
+    const peekEach = neighbourCount ? Math.max(MIN_PEEK, remainder / neighbourCount) : 0;
 
-    const hoveredIsNeighbour =
-      hoveredNeighborId !== null && neighbours.some((n) => n.id === hoveredNeighborId);
-    const widthOf = (n: RemoteEntry): number =>
-      hoveredIsNeighbour && n.id === hoveredNeighborId ? HOVER_PCT : peekEach;
+    const slotKey = (s: Slot): string => (s.kind === 'remote' ? s.remote.id : s.composite.id);
+    const isHovered = (s: Slot): boolean =>
+      hoveredNeighborId !== null && slotKey(s) === hoveredNeighborId;
+    const widthOf = (s: Slot): number => (isHovered(s) ? HOVER_PCT : peekEach);
 
     const items: StageItem[] = [];
-    if (prev) {
-      items.push({
-        id: prev.id, remote: prev, widthPct: widthOf(prev),
-        zIndex: prev.id === hoveredNeighborId ? 2 : 1, role: 'prev',
-      });
+    if (prevSlot) {
+      const item = materializeSlot(
+        prevSlot,
+        widthOf(prevSlot),
+        'prev',
+        isHovered(prevSlot) ? 2 : 1,
+      );
+      if (item) items.push(item);
     }
     const consumed =
-      (prev ? widthOf(prev) : 0) + (next ? widthOf(next) : 0);
-    items.push({
-      id: focused.id, remote: focused, widthPct: Math.max(20, 100 - consumed),
-      zIndex: 3, role: 'focused',
-    });
-    if (next) {
-      items.push({
-        id: next.id, remote: next, widthPct: widthOf(next),
-        zIndex: next.id === hoveredNeighborId ? 2 : 1, role: 'next',
-      });
+      (prevSlot ? widthOf(prevSlot) : 0) + (nextSlot ? widthOf(nextSlot) : 0);
+    const focused = materializeSlot(focusedSlot, Math.max(20, 100 - consumed), 'focused', 3);
+    if (focused) items.push(focused);
+    if (nextSlot) {
+      const item = materializeSlot(
+        nextSlot,
+        widthOf(nextSlot),
+        'next',
+        isHovered(nextSlot) ? 2 : 1,
+      );
+      if (item) items.push(item);
     }
     return items;
   });
 
   // ---- peek-flow: commit a neighbour as the new focus ---------------------
-  function commitFocus(remoteId: string): void {
-    const idx = REMOTES.findIndex((r) => r.id === remoteId);
+  function commitFocus(slotId: string): void {
+    const idx = ROTATION.findIndex((id) => id === slotId);
     if (idx >= 0) {
       hoveredNeighborId = null;
       layout.setFocusIndex(idx);
@@ -230,19 +247,27 @@
         | { remoteId?: string; mode?: LayoutMode }
         | undefined;
       if (!detail?.remoteId) return;
-      const idx = REMOTES.findIndex((r) => r.id === detail.remoteId);
-      if (idx >= 0) {
-        // Standard rotation remote — switch focus + mode as requested.
-        layout.setFocusIndex(idx);
+      // Direct rotation hit — the requested id is a slot in the rotation
+      // (a remote or a composite). Set focus + mode and we're done.
+      const rotIdx = ROTATION.findIndex((id) => id === detail.remoteId);
+      if (rotIdx >= 0) {
+        layout.setFocusIndex(rotIdx);
         layout.setMode(detail.mode ?? 'full');
         return;
       }
-      // Might be a composite member (e.g. packRunner inside enrichment).
-      // Set the composite's active member to the requested remote, then
-      // open the pairing that contains the composite.
+      // The id might be a composite member (e.g. `packRunner` inside the
+      // enrichment composite). Set the composite's active member; then
+      // either focus its rotation slot (if the composite is in ROTATION)
+      // or open its co-existence pairing.
       const composite = compositeFor(detail.remoteId);
       if (composite) {
         setCompositeMember(composite, detail.remoteId);
+        const compIdx = ROTATION.findIndex((id) => id === composite.id);
+        if (compIdx >= 0) {
+          layout.setFocusIndex(compIdx);
+          layout.setMode(detail.mode ?? 'full');
+          return;
+        }
         const pair = PAIRINGS.find(
           (p) => p.left === composite.id || p.right === composite.id,
         );
@@ -347,8 +372,16 @@
           activeId={activeMembers[item.composite.id] ?? item.composite.defaultMemberId}
           onSelect={(memberId) => setCompositeMember(item.composite!, memberId)}
         />
+        <!-- {#key activeMember} re-mounts MountHost when the toggle flips.
+             MountHost only runs its dynamic import in onMount, so without
+             the key change a swapped `remote` prop would leak the previous
+             member. -->
+        {#key activeMembers[item.composite.id]}
+          <MountHost remote={item.remote} />
+        {/key}
+      {:else}
+        <MountHost remote={item.remote} />
       {/if}
-      <MountHost remote={item.remote} />
 
       {#if !isInteractive}
         <!-- peek neighbour: a click-capture overlay. Hover expands it,
@@ -356,12 +389,12 @@
              not interactive while it is a neighbour. -->
         <button
           class="peek-overlay"
-          aria-label={`Focus ${item.remote.label}`}
+          aria-label={`Focus ${item.label}`}
           onmouseenter={() => (hoveredNeighborId = item.id)}
           onmouseleave={() => (hoveredNeighborId = null)}
           onclick={() => commitFocus(item.id)}
         >
-          <span class="peek-label">{item.remote.label}</span>
+          <span class="peek-label">{item.label}</span>
         </button>
       {/if}
 

--- a/shell/src/App.svelte
+++ b/shell/src/App.svelte
@@ -63,7 +63,7 @@
       ];
     }
 
-    // peek-deck
+    // peek-flow
     const i = layout.focusIndex;
     const focused = REMOTES[i];
     if (!focused) return [];
@@ -100,7 +100,7 @@
     return items;
   });
 
-  // ---- peek-deck: commit a neighbour as the new focus ---------------------
+  // ---- peek-flow: commit a neighbour as the new focus ---------------------
   function commitFocus(remoteId: string): void {
     const idx = REMOTES.findIndex((r) => r.id === remoteId);
     if (idx >= 0) {
@@ -109,7 +109,7 @@
     }
   }
 
-  // ---- focused-panel edge resize (peek-deck) ------------------------------
+  // ---- focused-panel edge resize (peek-flow) ------------------------------
   function startResize(e: PointerEvent): void {
     e.preventDefault();
     resizing = true;
@@ -196,7 +196,7 @@
   });
 
   const MODE_BUTTONS: { mode: LayoutMode; label: string }[] = [
-    { mode: 'peek-deck', label: 'Deck' },
+    { mode: 'peek-flow', label: 'Flow' },
     { mode: 'co-existence', label: 'Split' },
     { mode: 'full', label: 'Full' },
   ];

--- a/shell/src/App.svelte
+++ b/shell/src/App.svelte
@@ -405,14 +405,19 @@
     box-shadow: var(--fx-card-shadow);
   }
 
-  /* peek neighbour click-capture overlay */
+  /* peek neighbour click-capture overlay.
+     Labels anchor at the slice's left margin (spec Decision §6) — they
+     are landmarks, not floating titles. Uniform left-anchor across prev
+     and next peeks for now; if the right-peek's inner-edge label reads
+     wrong against the focused pane, revisit with role-aware positioning. */
   .peek-overlay {
     position: absolute;
     inset: 0;
     display: flex;
     align-items: flex-start;
-    justify-content: center;
+    justify-content: flex-start;
     padding-top: 1.5rem;
+    padding-left: 0.75rem;
     background: color-mix(in srgb, var(--color-background) 55%, transparent);
     border: 0;
     border-left: 1px solid var(--color-border);

--- a/shell/src/composites.ts
+++ b/shell/src/composites.ts
@@ -1,0 +1,82 @@
+// Composite slots — a shell-level concept where one slot in the layout
+// hosts one-of-N remotes based on shared state. The shell renders a
+// toggle header above the slot and mounts only the active member.
+//
+// Spec: context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md §5
+// Plan: context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md §2c
+//
+// PAIRINGS can reference a composite by id the same way they reference
+// a remote by id; slotById() in remotes.ts resolves either kind. The
+// active member is persisted to localStorage under the composite's
+// modeKey so the user's last choice survives reloads, and is broadcast
+// via a window event so any peer surface that cares (e.g. analytics)
+// can react without coupling.
+
+export type CompositeMember = {
+  remoteId: string;   // must resolve via remoteById()
+  icon: string;       // single-glyph display in the toggle header
+  label: string;      // tooltip + aria-label
+};
+
+export type CompositeEntry = {
+  id: string;
+  kind: 'composite';
+  label: string;
+  description: string;
+  modeKey: string;             // localStorage key + window event name
+  members: CompositeMember[];
+  defaultMemberId: string;
+};
+
+export const ENRICHMENT_COMPOSITE: CompositeEntry = {
+  id: 'enrichment',
+  kind: 'composite',
+  label: 'Enrichment',
+  description: 'Author a custom prompt OR fire a pre-built pack against the record set',
+  modeKey: 'augment-it:enrichment-mode',
+  members: [
+    {
+      remoteId: 'promptTemplateManager',
+      icon: '✎',
+      label: 'Custom prompt — author a free-text LLM prompt',
+    },
+    {
+      remoteId: 'packRunner',
+      icon: '⊞',
+      label: 'Pre-built pack — fire a source-bound pack against the record set',
+    },
+  ],
+  defaultMemberId: 'packRunner',
+};
+
+export const COMPOSITES: CompositeEntry[] = [ENRICHMENT_COMPOSITE];
+
+export function compositeById(id: string): CompositeEntry | undefined {
+  return COMPOSITES.find((c) => c.id === id);
+}
+
+/** Read the active member id for a composite from localStorage. */
+export function readActiveMemberId(c: CompositeEntry): string {
+  if (typeof localStorage === 'undefined') return c.defaultMemberId;
+  const stored = localStorage.getItem(c.modeKey);
+  if (!stored) return c.defaultMemberId;
+  // Backwards-compat: Phase 2b stored 'prompt' / 'pack' literals; map them
+  // to the new remote-id values. Remove after one release.
+  if (stored === 'prompt') return 'promptTemplateManager';
+  if (stored === 'pack') return 'packRunner';
+  // Validate it's a known member; otherwise fall back to the default.
+  return c.members.some((m) => m.remoteId === stored) ? stored : c.defaultMemberId;
+}
+
+/** Write the active member id and broadcast the change. */
+export function writeActiveMemberId(c: CompositeEntry, memberId: string): void {
+  if (typeof localStorage !== 'undefined') localStorage.setItem(c.modeKey, memberId);
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(c.modeKey, { detail: { memberId } }));
+  }
+}
+
+/** If a remote id belongs to a composite, return that composite. */
+export function compositeFor(remoteId: string): CompositeEntry | undefined {
+  return COMPOSITES.find((c) => c.members.some((m) => m.remoteId === remoteId));
+}

--- a/shell/src/layout.svelte.ts
+++ b/shell/src/layout.svelte.ts
@@ -12,12 +12,12 @@
 
 import { REMOTES, PAIRINGS } from './remotes';
 
-export type LayoutMode = 'peek-deck' | 'co-existence' | 'full';
+export type LayoutMode = 'peek-flow' | 'co-existence' | 'full';
 
 export type ShellLayoutPreference = {
   mode: LayoutMode;
-  focusIndex: number;                       // peek-deck / full: position in REMOTES
-  focusedWidthPct: number;                  // peek-deck: user-adjusted focused width
+  focusIndex: number;                       // peek-flow / full: position in REMOTES
+  focusedWidthPct: number;                  // peek-flow: user-adjusted focused width
   coExistenceRatios: Record<string, number>; // pair key → left-panel %
   defaultMode: LayoutMode;
 };
@@ -25,20 +25,36 @@ export type ShellLayoutPreference = {
 const STORAGE_KEY = 'augment-it:shell-layout';
 
 const DEFAULTS: ShellLayoutPreference = {
-  mode: 'peek-deck',
+  mode: 'peek-flow',
   focusIndex: 0,
   focusedWidthPct: 90,
   coExistenceRatios: {},
-  defaultMode: 'peek-deck',
+  defaultMode: 'peek-flow',
 };
+
+// One-time migration for the Deck → Flow rename (spec Decision §7).
+// Old persisted snapshots have mode/defaultMode as 'peek-deck'; map to
+// 'peek-flow' on read so existing users don't lose their layout.
+function migrateMode(mode: unknown): LayoutMode | undefined {
+  if (mode === 'peek-deck') return 'peek-flow';
+  if (mode === 'peek-flow' || mode === 'co-existence' || mode === 'full') return mode;
+  return undefined;
+}
 
 function readStored(): ShellLayoutPreference {
   if (typeof localStorage === 'undefined') return { ...DEFAULTS };
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return { ...DEFAULTS };
-    const parsed = JSON.parse(raw) as Partial<ShellLayoutPreference>;
-    return { ...DEFAULTS, ...parsed, coExistenceRatios: { ...parsed.coExistenceRatios } };
+    const parsed = JSON.parse(raw) as Partial<ShellLayoutPreference> & {
+      mode?: unknown; defaultMode?: unknown;
+    };
+    const migrated: Partial<ShellLayoutPreference> = {
+      ...parsed,
+      mode: migrateMode(parsed.mode),
+      defaultMode: migrateMode(parsed.defaultMode),
+    };
+    return { ...DEFAULTS, ...migrated, coExistenceRatios: { ...parsed.coExistenceRatios } };
   } catch {
     return { ...DEFAULTS };
   }
@@ -96,7 +112,7 @@ class ShellLayout {
     this.persist();
   }
 
-  /** Drag the focused panel's edge (peek-deck). */
+  /** Drag the focused panel's edge (peek-flow). */
   setFocusedWidth(pct: number): void {
     this.focusedWidthPct = clamp(pct, FOCUSED_WIDTH_MIN, FOCUSED_WIDTH_MAX);
     this.persist();

--- a/shell/src/layout.svelte.ts
+++ b/shell/src/layout.svelte.ts
@@ -10,7 +10,7 @@
 // are the one adapter; swapping the storage is swapping this file's two
 // private functions, nothing else.
 
-import { REMOTES, PAIRINGS } from './remotes';
+import { ROTATION, PAIRINGS } from './remotes';
 
 export type LayoutMode = 'peek-flow' | 'co-existence' | 'full';
 
@@ -78,7 +78,7 @@ class ShellLayout {
   constructor() {
     const p = readStored();
     this.mode = $state<LayoutMode>(p.mode);
-    this.focusIndex = $state<number>(clamp(p.focusIndex, 0, REMOTES.length - 1));
+    this.focusIndex = $state<number>(clamp(p.focusIndex, 0, ROTATION.length - 1));
     this.focusedWidthPct = $state<number>(clamp(p.focusedWidthPct, FOCUSED_WIDTH_MIN, FOCUSED_WIDTH_MAX));
     this.coExistenceRatios = $state<Record<string, number>>(p.coExistenceRatios);
     this.defaultMode = $state<LayoutMode>(p.defaultMode);
@@ -108,7 +108,7 @@ class ShellLayout {
 
   /** No wrap — clamped to the sequence ends. */
   setFocusIndex(index: number): void {
-    this.focusIndex = clamp(index, 0, REMOTES.length - 1);
+    this.focusIndex = clamp(index, 0, ROTATION.length - 1);
     this.persist();
   }
 

--- a/shell/src/remotes.ts
+++ b/shell/src/remotes.ts
@@ -70,7 +70,7 @@ export const CHAT_REMOTE: RemoteEntry = {
 // PACK_RUNNER_REMOTE is intentionally NOT in REMOTES. Per the
 // [[Run-as-First-Class-Operation]] plan §Part 1: Pack Runner is the
 // alternative to authoring a custom prompt, reached as an "option" from
-// prompt-template-manager, not as a sibling tile in the peek-deck. The
+// prompt-template-manager, not as a sibling tile in the peek-flow. The
 // federation registration is still in rsbuild.config.ts so the PAIRING
 // lookup + cross-remote navigation event continue to work.
 export const PACK_RUNNER_REMOTE: RemoteEntry = {
@@ -82,7 +82,7 @@ export const PACK_RUNNER_REMOTE: RemoteEntry = {
 };
 
 // "Extra" remotes — federation-registered + reachable via PAIRING /
-// augment-it:navigate, but excluded from the peek-deck rotation in REMOTES.
+// augment-it:navigate, but excluded from the peek-flow rotation in REMOTES.
 // Same shape as CHAT_REMOTE; aggregated here so remoteById() can fall back
 // to look them up without each caller having to know about each extra.
 const EXTRA_REMOTES: RemoteEntry[] = [CHAT_REMOTE, PACK_RUNNER_REMOTE];

--- a/shell/src/remotes.ts
+++ b/shell/src/remotes.ts
@@ -3,6 +3,15 @@
 // Adding a remote is a REMOTES entry + a `remotes` map line in
 // rsbuild.config.ts — nothing else in the shell. Adding a co-existence
 // pairing is a PAIRINGS entry.
+//
+// A PAIRING slot may reference either a remote id (the common case) or a
+// composite id from composites.ts (a slot that hosts one-of-N remotes
+// based on shared state — see [[Shell-and-Micro-Frontend-UX-Coherence-Refactor]]
+// Phase 2c). slotById() resolves either kind.
+
+import { compositeById, type CompositeEntry } from './composites';
+export { compositeById } from './composites';
+export type { CompositeEntry } from './composites';
 
 export type RemoteEntry = {
   id: string;
@@ -99,10 +108,14 @@ export type Pairing = {
 
 export const PAIRINGS: Pairing[] = [
   {
-    key: 'recordCollector+promptTemplateManager',
+    // The enrichment composite (PTM ⇄ Pack Runner) paired with Record
+    // Collector. Replaces the two former pairings recordCollector+PTM and
+    // packRunner+PTM. The composite owns the in-slot toggle; the shell
+    // mounts only the active member at a time. Phase 2c of the refactor.
+    key: 'recordCollector+enrichment',
     left: 'recordCollector',
-    right: 'promptTemplateManager',
-    defaultLeftPct: 30, // record-collector 30 / prompt-template-manager 70
+    right: 'enrichment',
+    defaultLeftPct: 30,
   },
   {
     // Per Enhanced-Records-List spec §"Surface": pair the new checkpoint
@@ -113,18 +126,25 @@ export const PAIRINGS: Pairing[] = [
     right: 'enhancedRecordsList',
     defaultLeftPct: 25, // record-collector narrower; the checkpoint table needs room
   },
-  {
-    // Per [[Run-as-First-Class-Operation]] §Part 1: prompt-templates and
-    // pack-runner are the two ways to enrich a record set (custom LLM
-    // prompt vs source-bound pack), so they belong in one viewport.
-    // Equal billing by default — neither dominates the workflow.
-    key: 'packRunner+promptTemplateManager',
-    left: 'promptTemplateManager',
-    right: 'packRunner',
-    defaultLeftPct: 50,
-  },
 ];
 
 export function remoteById(id: string): RemoteEntry | undefined {
   return REMOTES.find((r) => r.id === id) ?? EXTRA_REMOTES.find((r) => r.id === id);
+}
+
+/**
+ * A slot in a layout can be either a single remote or a composite that
+ * hosts one-of-N remotes. Use slotById when you need to handle both —
+ * e.g. when rendering a PAIRING half.
+ */
+export type Slot =
+  | { kind: 'remote'; remote: RemoteEntry }
+  | { kind: 'composite'; composite: CompositeEntry };
+
+export function slotById(id: string): Slot | undefined {
+  const r = remoteById(id);
+  if (r) return { kind: 'remote', remote: r };
+  const c = compositeById(id);
+  if (c) return { kind: 'composite', composite: c };
+  return undefined;
 }

--- a/shell/src/remotes.ts
+++ b/shell/src/remotes.ts
@@ -22,6 +22,23 @@ export type RemoteEntry = {
   importMount: () => Promise<Record<string, unknown>>;
 };
 
+/**
+ * Ordered list of slot ids that walk the peek-flow rotation (and the
+ * full-mode focus sequence). Each id resolves via slotById() to either
+ * a federated remote or a composite. Composites are peers in the
+ * rotation, so the in-slot toggle (e.g. enrichment's PTM⇄Pack-Runner
+ * pair) works in every layout mode, not just co-existence.
+ *
+ * Phase 2d of the refactor — see context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
+ */
+export const ROTATION: string[] = [
+  'recordCollector',
+  'enrichment',          // composite — PTM ⇄ Pack Runner via in-slot toggle
+  'requestReviewer',
+  'responseReviewer',
+  'enhancedRecordsList',
+];
+
 export const REMOTES: RemoteEntry[] = [
   {
     id: 'recordCollector',


### PR DESCRIPTION
## Summary

  First chunk of the **Shell & Micro-Frontend UX Coherence** refactor. Lands four
  of the spec's eight decisions and resolves the architectural spike that was
  gating Phase 5. Six-phase plan continues on this branch or follow-ups; this PR
  is mergeable on its own.

  - **Vocabulary:** `Deck` → `Flow` across the shell (spec Decision §7), with a
    one-line localStorage migration so existing layout preferences survive.
  - **Peek labels** anchored at the slice's left margin instead of floating
    centered (spec Decision §6) — they read as landmarks now.
  - **Composite slot** concept in the shell + shared toggle component
    (`packages/shared-ui/src/ToggleHeader__PromptOrPackage--Icons.svelte`).
    Replaces the side-by-side enrichment pair with a single slot that hosts
    Prompt Templates *or* Pack Runner via an in-slot ✎/⊞ toggle. Resolves the
    spike (was "wrapper-remote vs shared-state") as **Option C — composite slot**
    (spec Decision §5).
  - **Composites are peers in the Flow rotation.** Introduced `ROTATION` as the
    rotation order (separate from `REMOTES`, the federated registry) so the
    in-slot toggle works in Flow, Split, and Full alike.

  ## Why this matters (for the reader landing here cold)

  Today, in Split mode, picking "Pre-built Pack →" inside Prompt Templates
  lights up Pack Runner on the right *and* leaves the prompt editor visible
  underneath on the left. Two flows compete for the eye. After this PR, the
  enrichment surface is one slot: you see PTM or Pack Runner, never both,
  and the slot's toggle works the same in every layout mode.

  ## Phases shipped

  | Phase | Status | Commit | Notes |
  |---|---|---|---|
  | 0 — Branch + plan | ✅ | `57ba225` | six-phase plan committed at
  `context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md` |
  | 1 — Deck → Flow rename | ✅ | `7cf9b46` | spec §7 |
  | 2a — Peek labels anchor left | ✅ | `3cd5756` | spec §6 |
  | 2b — Enrichment icon-switcher (intra-remote) | ↩︎ | `62731fd` | shipped, then superseded by 2c — see "How the
   spike resolved itself" below |
  | 2c — Composite slot + shared toggle | ✅ | `b9b99df` | spec §5; resolves the spike |
  | 2d — Composites are peers in Flow rotation | ✅ | `664f728` | makes the toggle work in every layout mode |
  | Changelog | ✅ | `0023c47` | `changelog/2026-06-01_03_Composite-Slots-and-the-Flow-Rename.md` |

  Phases 3-6 are scoped in the plan but live on follow-up branches:
  - **Phase 3 — bundle-first Pack Runner.** Replaces the spec's conservative
    Decision §1 (none/solo/all on a flat pack list) with Bundle as the
    primary selector, per [[Packs-and-Bundles-Pattern]].
  - **Phase 4 — hierarchical Flow widget** (spec §8): bubble progress strip
    derived from `ROTATION`, Split/Full as icon-tooltip toggles beneath Flow.
  - **Phase 5 — Augment This Set** (spec §4) + record-set key unification.
  - **Phase 6 — cross-cutting principles + per-surface audit harvest.**

  ## How the spike resolved itself

  The plan flagged "enrichment composition — wrapper remote vs shared-state"
  as a spike that gated Phase 5. We shipped Phase 2b (the intra-remote icon
  switcher + off-mode body hide) as the smaller-change shared-state path,
  pushed it to the running shell, and immediately saw the architectural
  break: the toggle worked but Split still mounted *both* remotes
  side-by-side; one just rendered empty.

  That eyeball made the right shape visible — neither wrapper remote nor
  shared-state alone. **Option C: a shell-level "composite slot" concept
  that hosts one-of-N remotes.** Phase 2c implements it and reverts Phase
  2b's intra-remote work in the same commit. The diff is large but the
  revert context lives in it for anyone retracing.

  Phase 2d caught a second gap: composites were resolved by `slotById` in
  co-existence mode but the rotation (peek-flow + full) still iterated
  `REMOTES` directly. So we separated "what federated remotes exist"
  (`REMOTES`, the registry) from "what slots are in the rotation"
  (`ROTATION`, an ordered list of slot ids that includes composites). All
  rotation operations (`commitFocus`, navigate handler, peek-flow stage
  builder, `layout.setFocusIndex` clamping) now walk `ROTATION` via
  `slotById`. The composite is a first-class rotation step.

  ## Key files

  **New:**
  - `shell/src/composites.ts` — `CompositeEntry`, `ENRICHMENT_COMPOSITE`,
    read/write/broadcast helpers, backwards-compat read for Phase 2b's
    literal modes.
  - `packages/shared-ui/src/ToggleHeader__PromptOrPackage--Icons.svelte` —
    pure-presentation icon-with-tooltip pair; receives `{ members,
    activeId, onSelect }`; owns no state.
  - `context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md` —
    the six-phase plan, v0.0.0.3 with the spike resolution and Phase 2d
    recorded in revisions.
  - `changelog/2026-06-01_03_Composite-Slots-and-the-Flow-Rename.md` — the
    public-facing arc.

  **Modified:**
  - `shell/src/App.svelte` — composite-aware stage builder, navigate
    handler, peek-label rendering, `{#key}` re-mount around composite
    MountHost so the toggle re-mounts cleanly, peek labels anchored left.
  - `shell/src/remotes.ts` — `ROTATION`, `Slot` union, `slotById()`,
    PAIRINGS collapsed to `recordCollector+enrichment`.
  - `shell/src/layout.svelte.ts` — `LayoutMode` literal `peek-deck` →
    `peek-flow`, one-time migration in `readStored()`, clamping against
    `ROTATION.length`.
  - `apps/prompt-template-manager/src/{App.svelte,app.css}` — reverts the
    Phase 2b intra-remote toggle + off-mode wrapper + dead `EnrichmentMode`
    state.
  - `apps/pack-runner/src/{App.svelte,app.css}` — symmetric revert.
  - `shell/package.json` — `@augment-it/shared-ui` workspace dependency.

  ## Migration / risk

  - **localStorage migration** for the rename — `readStored()` maps any
    persisted `'peek-deck'` to `'peek-flow'` on first load. Defensive; no
    user action needed.
  - **Backwards-compat read in `composites.ts`** maps Phase 2b's literal
    modes (`'prompt'` / `'pack'`) to the new remote-id values. Remove
    after one release.
  - **`pack.fan_out` unchanged** in this PR. Phase 3 will add an optional
    `bundle_id` parameter; old call sites continue to work.

  ## Verification

  - `pnpm build` clean in `shell/`, `apps/prompt-template-manager/`,
    `apps/pack-runner/`.
  - `svelte-check` shows one pre-existing `HTMLDivElement`-vs-`HTMLElement`
    warning on `stageEl` in `App.svelte` — unrelated, predates this branch.

  ## Test plan

  - [ ] **Flow mode:** rotation steps through Record Collector → Enrichment
        → Request Reviewer → Response Reviewer → Enhanced Records. Focused
        Enrichment slice shows ✎/⊞ at top; clicking toggles between PTM
        and Pack Runner without leaving Flow.
  - [ ] **Split mode:** clicking "Split" opens Record Collector ⇄
        Enrichment. Same toggle on the right pane; same swap behavior.
  - [ ] **Full mode:** focusing Enrichment shows the toggle at top.
  - [ ] **Peek labels:** in Flow, the vertical per-pane labels sit at the
        slice's left margin rather than centered.
  - [ ] **Cross-remote nav:** dispatching `augment-it:navigate { remoteId:
        'packRunner' }` from outside (e.g. browser console) sets Enrichment's
        active member to Pack Runner and focuses it in the current mode.
  - [ ] **localStorage migration:** open the app with a `'peek-deck'`
        value pre-set in `augment-it:shell-layout`; layout should load as
        Flow with no errors.
  - [ ] **Reload persistence:** flip the toggle, reload, the same member
        is active.

  ## Related

  - Spec: `context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md`
  - Plan: `context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md`
  - Companion changelog: `changelog/2026-06-01_03_Composite-Slots-and-the-Flow-Rename.md`
  - Prior in-progress work that Phase 5 will integrate with:
    `context-v/plans/Run-as-First-Class-Operation.md` Part 4

  🤖 Generated with [Claude Code](https://claude.com/claude-code)