### PR TITLE
Bundle-first Pack Runner (Phase 3) + spec reconciliation

### DIFF
--- a/apps/pack-runner/src/App.svelte
+++ b/apps/pack-runner/src/App.svelte
@@ -1,19 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { workspace, type RecordSet, type Row } from '@augment-it/workspace';
-
-  // Six pack identities. Source-of-truth lives in services/social-search/src/packs.ts;
-  // keeping the labels here client-side avoids a round-trip just to render the UI.
-  // If a pack lands or is renamed, update both.
-  const PACKS: { pack_id: string; display_name: string }[] = [
-    { pack_id: 'linkedin-pack', display_name: 'LinkedIn' },
-    { pack_id: 'x-pack', display_name: 'X / Twitter' },
-    { pack_id: 'bluesky-pack', display_name: 'BlueSky' },
-    { pack_id: 'youtube-pack', display_name: 'YouTube' },
-    { pack_id: 'facebook-pack', display_name: 'Facebook' },
-    { pack_id: 'wikipedia-pack', display_name: 'Wikipedia' },
-    { pack_id: 'instagram-pack', display_name: 'Instagram' },
-  ];
+  import { BUNDLES, getBundle, packDisplayName, type BundleConfig } from './bundles';
 
   const TOKEN_KEY = 'augment-it:session-token';
   const WS_URL = 'ws://localhost:3001/ws';
@@ -23,6 +11,10 @@
   // the existing localStorage convention.
   const RECORD_SET_KEY = 'augment-it:pack-runner:record-set';
   const ENTITY_FIELD_KEY = 'augment-it:pack-runner:entity-name-field';
+  // Bundle-aware persistence (Phase 3): the active bundle id, plus per-bundle
+  // roster-override sets so swapping bundles doesn't lose user tuning per bundle.
+  const BUNDLE_ID_KEY = 'augment-it:pack-runner:bundle-id';
+  const ROSTER_OVERRIDES_KEY_PREFIX = 'augment-it:pack-runner:roster-overrides:';
 
   function readStored(key: string): string | null {
     if (typeof localStorage === 'undefined') return null;
@@ -34,13 +26,42 @@
     else localStorage.setItem(key, value);
   }
 
+  // Bundle-aware roster reads. A bundle's "effective roster" = its
+  // default-true members, unless the user has saved an override set for
+  // that bundle id (in which case the override IS the roster).
+  function defaultRoster(bundle: BundleConfig): Set<string> {
+    return new Set(bundle.members.filter((m) => m.default).map((m) => m.pack_id));
+  }
+  function readRoster(bundle_id: string): Set<string> | null {
+    const raw = readStored(ROSTER_OVERRIDES_KEY_PREFIX + bundle_id);
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw) as string[];
+      return Array.isArray(parsed) ? new Set(parsed) : null;
+    } catch {
+      return null;
+    }
+  }
+  function writeRoster(bundle_id: string, roster: Set<string>): void {
+    writeStored(ROSTER_OVERRIDES_KEY_PREFIX + bundle_id, JSON.stringify([...roster]));
+  }
+
+  // Active bundle — defaults to the first registered bundle if no preference
+  // is stored. We auto-write the chosen bundle's roster on first load so
+  // every persisted roster is explicit (no implicit "use defaults").
+  const initialBundleId = readStored(BUNDLE_ID_KEY) ?? BUNDLES[0].bundle_id;
+  const initialBundle = getBundle(initialBundleId) ?? BUNDLES[0];
+
   let status = $state<'connecting' | 'open' | 'closed' | 'error'>('connecting');
   let recordSets = $state<RecordSet[]>([]);
   let selectedRecordSetId = $state<string | null>(readStored(RECORD_SET_KEY));
   let rowsForSelected = $state<Row[]>([]);
   let selectedRowIds = $state<Set<string>>(new Set());
   let entityNameField = $state<string>(readStored(ENTITY_FIELD_KEY) ?? '');
-  let enabledPackIds = $state<Set<string>>(new Set(PACKS.map((p) => p.pack_id)));
+  let activeBundleId = $state<string>(initialBundle.bundle_id);
+  let enabledPackIds = $state<Set<string>>(
+    readRoster(initialBundle.bundle_id) ?? defaultRoster(initialBundle),
+  );
   let firing = $state(false);
   let lastResult = $state<string>('');
 
@@ -48,7 +69,9 @@
     selectedRecordSetId ? recordSets.find((rs) => rs.record_set_id === selectedRecordSetId) ?? null : null,
   );
   const columns = $derived(selectedSet?.schema.fields.map((f) => f.name) ?? []);
+  const activeBundle = $derived(getBundle(activeBundleId) ?? BUNDLES[0]);
   const enabledPackCount = $derived(enabledPackIds.size);
+  const rosterSize = $derived(activeBundle.members.length);
 
   // Row filter — heuristic v1: classify each row by whether its `url` column
   // already has a real value vs being empty/'unknown'. Maps to the user's
@@ -172,11 +195,46 @@
     if (entityNameField) writeStored(ENTITY_FIELD_KEY, entityNameField);
   });
 
+  // Roster operations — all persist the override under the active bundle's
+  // key. They mutate the *current bundle's* roster only; switching bundles
+  // restores that bundle's own override (or its defaults).
   function togglePack(pack_id: string) {
     const next = new Set(enabledPackIds);
     if (next.has(pack_id)) next.delete(pack_id);
     else next.add(pack_id);
     enabledPackIds = next;
+    writeRoster(activeBundleId, next);
+  }
+
+  function rosterAll() {
+    const next = new Set(activeBundle.members.map((m) => m.pack_id));
+    enabledPackIds = next;
+    writeRoster(activeBundleId, next);
+  }
+  function rosterNone() {
+    const next = new Set<string>();
+    enabledPackIds = next;
+    writeRoster(activeBundleId, next);
+  }
+  function rosterSolo(pack_id: string) {
+    const next = new Set<string>([pack_id]);
+    enabledPackIds = next;
+    writeRoster(activeBundleId, next);
+  }
+  function rosterDefaults() {
+    const next = defaultRoster(activeBundle);
+    enabledPackIds = next;
+    writeRoster(activeBundleId, next);
+  }
+
+  function selectBundle(bundle_id: string) {
+    if (bundle_id === activeBundleId) return;
+    const b = getBundle(bundle_id);
+    if (!b) return;
+    activeBundleId = bundle_id;
+    writeStored(BUNDLE_ID_KEY, bundle_id);
+    // Restore that bundle's own override, or its defaults.
+    enabledPackIds = readRoster(bundle_id) ?? defaultRoster(b);
   }
 
   function toggleRow(row_id: string) {
@@ -215,6 +273,9 @@
         row_ids: effectiveSelection.map((r) => r.row_id),
         record_set_id: selectedRecordSetId,
         entity_name_field: entityNameField,
+        // The bundle this fan-out belongs to — rides on every ResponseRecord
+        // so Response Reviewer can group results by bundle. New in Phase 3.
+        bundle_id: activeBundleId,
       })) as { ok: boolean; cells_fired?: number; error?: string };
       if (r.ok) {
         lastResult = `Fired ${r.cells_fired ?? cellsToFire} cells — all settled. Open Response Reviewer to triage.`;
@@ -251,9 +312,8 @@
     <div class="pr-head">
       <h2>Pack Runner</h2>
       <p class="muted">
-        Fire the common-six social packs against rows of a record set.
-        Results land in Response Reviewer with a confidence pill — triage
-        them there.
+        Pick a bundle, scope it to the rows you want, fire it. Results land
+        in Response Reviewer with a confidence pill — triage them there.
       </p>
     </div>
 
@@ -339,17 +399,58 @@
       </section>
 
       <section class="card">
-        <h3>4 · Packs ({enabledPackCount}/{PACKS.length})</h3>
+        <h3>4 · Bundle</h3>
+        <p class="muted hint">
+          A bundle is a named composition of packs with a default roster.
+          Pick one to set what fires; tune the roster below if you need to.
+        </p>
+        <div class="bundle-picker" role="tablist" aria-label="Bundle">
+          {#each BUNDLES as b (b.bundle_id)}
+            <button
+              class="bundle-chip"
+              class:active={b.bundle_id === activeBundleId}
+              role="tab"
+              aria-selected={b.bundle_id === activeBundleId}
+              title={b.description}
+              onclick={() => selectBundle(b.bundle_id)}
+            >
+              {b.display_name}
+            </button>
+          {/each}
+        </div>
+        <p class="muted bundle-desc">{activeBundle.description}</p>
+      </section>
+
+      <section class="card">
+        <h3>5 · Roster ({enabledPackCount}/{rosterSize})</h3>
+        <p class="muted hint">
+          The bundle's packs — defaults are checked. Toggle to override; use
+          <strong>solo</strong> next to a pack to fire just that one.
+        </p>
+        <div class="row-actions">
+          <button class="chip" onclick={rosterAll}>all</button>
+          <button class="chip" onclick={rosterNone}>none</button>
+          <button class="chip" onclick={rosterDefaults}>defaults</button>
+        </div>
         <div class="packs">
-          {#each PACKS as pack (pack.pack_id)}
-            <label class="pack-chip">
-              <input
-                type="checkbox"
-                checked={enabledPackIds.has(pack.pack_id)}
-                onchange={() => togglePack(pack.pack_id)}
-              />
-              <span>{pack.display_name}</span>
-            </label>
+          {#each activeBundle.members as m (m.pack_id)}
+            <div class="pack-row">
+              <label class="pack-chip">
+                <input
+                  type="checkbox"
+                  checked={enabledPackIds.has(m.pack_id)}
+                  onchange={() => togglePack(m.pack_id)}
+                />
+                <span>{packDisplayName(m.pack_id)}</span>
+                {#if !m.default}<span class="muted pack-optin">opt-in</span>{/if}
+              </label>
+              <button
+                type="button"
+                class="solo"
+                title="Fire only {packDisplayName(m.pack_id)} for this bundle"
+                onclick={() => rosterSolo(m.pack_id)}
+              >solo</button>
+            </div>
           {/each}
         </div>
       </section>
@@ -362,11 +463,11 @@
             onclick={() => void fire()}
           >
             {#if firing}
-              firing on {selectedRowCount} {selectedRowCount === 1 ? 'row' : 'rows'}…
+              firing {activeBundle.display_name} on {selectedRowCount} {selectedRowCount === 1 ? 'row' : 'rows'}…
             {:else if cellsToFire === 0}
-              select rows and packs to fire
+              select rows and roster to fire
             {:else}
-              Fire on {selectedRowCount} {selectedRowCount === 1 ? 'row' : 'rows'}
+              Fire {activeBundle.display_name} on {selectedRowCount} {selectedRowCount === 1 ? 'row' : 'rows'}
             {/if}
           </button>
           <button class="to-reviewer" onclick={goToResponseReviewer}>

--- a/apps/pack-runner/src/app.css
+++ b/apps/pack-runner/src/app.css
@@ -183,6 +183,66 @@
 .pr-app .pack-chip:hover { border-color: var(--color-accent); }
 .pr-app .pack-chip input { margin: 0; }
 
+/* Bundle picker (Phase 3) — segmented control above the roster panel.
+   Re-uses the chip aesthetic but with a stronger active state since the
+   bundle decides what fires. */
+.pr-app .bundle-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.4rem 0 0.6rem;
+}
+.pr-app .bundle-chip {
+  background: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  letter-spacing: 0.02em;
+}
+.pr-app .bundle-chip:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+.pr-app .bundle-chip.active {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  border-color: var(--color-accent);
+  cursor: default;
+}
+.pr-app .bundle-desc {
+  font-size: 0.75rem;
+  margin: 0.3rem 0 0;
+}
+
+/* Per-pack row with a solo affordance. The chip lays out the same way as
+   before; solo is a small right-aligned text button. */
+.pr-app .pack-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.pr-app .pack-row .solo {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--color-text-muted);
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  cursor: pointer;
+  letter-spacing: 0.02em;
+}
+.pr-app .pack-row .solo:hover {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+.pr-app .pack-optin {
+  font-size: 0.7rem;
+  margin-left: 0.2rem;
+}
+
 /* Pinned to the bottom of the scroll container so the run action stays
    reachable no matter how long the row/pack lists get. */
 .pr-app .fire-card {

--- a/apps/pack-runner/src/bundles.ts
+++ b/apps/pack-runner/src/bundles.ts
@@ -1,0 +1,77 @@
+// Client-side bundle registry — kept in sync by hand with the service
+// source of truth at services/social-search/src/bundles.ts.
+// Matches the same one-file-each convention as packs.ts. If a bundle
+// lands or its roster changes, update both files.
+//
+// Spec: ../../../context-v/blueprints/Packs-and-Bundles-Pattern.md
+// Plan: ../../../context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md §Phase 3
+
+export type BundleMember = {
+  pack_id: string;
+  default: boolean;
+  pass: 1 | 2;
+  required: boolean;
+};
+
+export type BundleConfig = {
+  bundle_id: string;
+  display_name: string;
+  description: string;
+  entity_type?: string;
+  passes: 1 | 2;
+  members: BundleMember[];
+};
+
+export const PROFILE_BUILDER: BundleConfig = {
+  bundle_id: 'profile-builder',
+  display_name: 'Profile Builder',
+  description: 'Common-five social packs + Wikipedia — for any entity that lives on the public web',
+  passes: 1,
+  members: [
+    { pack_id: 'linkedin-pack',  default: true,  pass: 1, required: false },
+    { pack_id: 'x-pack',         default: true,  pass: 1, required: false },
+    { pack_id: 'bluesky-pack',   default: true,  pass: 1, required: false },
+    { pack_id: 'youtube-pack',   default: true,  pass: 1, required: false },
+    { pack_id: 'wikipedia-pack', default: true,  pass: 1, required: false },
+    { pack_id: 'facebook-pack',  default: false, pass: 1, required: false },
+    { pack_id: 'instagram-pack', default: false, pass: 1, required: false },
+  ],
+};
+
+export const PROFILE_BUILDER_NONPROFIT: BundleConfig = {
+  bundle_id: 'profile-builder.nonprofit',
+  display_name: 'Profile Builder · Nonprofit',
+  description: 'Common-five + Wikipedia, biased for org-shaped entities; nonprofit-specific packs (Candid, ProPublica, IRS 990) opt-in once they ship',
+  entity_type: 'nonprofit',
+  passes: 1,
+  members: [
+    { pack_id: 'linkedin-pack',  default: true,  pass: 1, required: false },
+    { pack_id: 'x-pack',         default: true,  pass: 1, required: false },
+    { pack_id: 'bluesky-pack',   default: true,  pass: 1, required: false },
+    { pack_id: 'youtube-pack',   default: true,  pass: 1, required: false },
+    { pack_id: 'wikipedia-pack', default: true,  pass: 1, required: false },
+    { pack_id: 'facebook-pack',  default: false, pass: 1, required: false },
+    { pack_id: 'instagram-pack', default: false, pass: 1, required: false },
+  ],
+};
+
+export const BUNDLES: BundleConfig[] = [PROFILE_BUILDER, PROFILE_BUILDER_NONPROFIT];
+
+export function getBundle(bundle_id: string): BundleConfig | undefined {
+  return BUNDLES.find((b) => b.bundle_id === bundle_id);
+}
+
+/** Pack-display-name lookup table; the Pack Runner UI shows these in the roster. */
+export const PACK_DISPLAY_NAMES: Record<string, string> = {
+  'linkedin-pack':  'LinkedIn',
+  'x-pack':         'X / Twitter',
+  'bluesky-pack':   'BlueSky',
+  'youtube-pack':   'YouTube',
+  'facebook-pack':  'Facebook',
+  'wikipedia-pack': 'Wikipedia',
+  'instagram-pack': 'Instagram',
+};
+
+export function packDisplayName(pack_id: string): string {
+  return PACK_DISPLAY_NAMES[pack_id] ?? pack_id;
+}

--- a/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
+++ b/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
@@ -419,7 +419,7 @@ a new `enrichmentSurface` remote — depends on it.
 | 2b — Enrichment-mode exclusive UI (intra-remote) | ✅→↩ | 62731fd | superseded by 2c |
 | 2c — Composite slot + shared toggle | ✅ | b9b99df | resolves the spike |
 | 2d — Composites are peers in Flow rotation | ⏳ | — | ROTATION peer to REMOTES; in-slot toggle works in Flow & Full too |
-| 3 — Bundle-first Pack Runner | ⏳ | — | supersedes spec §1 helpers |
+| 3 — Bundle-first Pack Runner | ✅ | 126a534 | supersedes spec §1 helpers; on feat/bundle-first-pack-runner |
 | 4 — Flow widget | ⏳ | — | |
 | 5 — Augment This Set + key unification | ⏳ | — | gated on spike |
 | 6 — Principles + audit harvest | ⏳ | — | |

--- a/context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md
+++ b/context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md
@@ -2,12 +2,15 @@
 title: "Shell & Micro-Frontend UX Coherence — Affordances That Are Found, Consistent, and Talk Back"
 lede: "One demo-prep session turned into a chain of 'I can't find / reach / trigger X' failures across Pack Runner, Enhanced Records, and Response Reviewer. Individually each was a one-line patch; together they're a verdict — the augment-it shell's affordances hide, die, or mismatch. This spec audits the whole shell + its micro-frontends through that lens and fixes the pattern, not just the instances."
 date_created: 2026-05-28
-date_modified: 2026-05-28
+date_modified: 2026-06-01
 authors:
   - Michael Staton
 augmented_with:
   - Claude Code on Claude Opus 4.7
-semantic_version: 0.0.0.1
+semantic_version: 0.0.0.2
+revisions:
+  - 2026-05-28 — Initial audit + 8 locked decisions (0.0.0.1).
+  - 2026-06-01 — Shipped Phases 0–2d of [[../plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor]]. Marked Decisions §6 (peek labels), §7 (Deck → Flow), and §5 (composition) as shipped. The §5 open question "wrapper remote vs shared-state" resolved as **Option C — shell-level composite slot**; recorded in Decision §5 and removed from Open questions. Decision §1 (pack selection helpers on a flat list) **superseded** by Phase 3 bundle-first refactor — the plan's reconciliation against [[../blueprints/Packs-and-Bundles-Pattern]] showed that polishing a flat 7-pack list cements a model the blueprint says is wrong. Open question about Enrichment in the Flow strip resolved: **one bubble**, locked by the `ROTATION` shape shipped in Phase 2d. Per-surface audit updated with shipped status. Plan-level history lives in the plan; spec-level history is just the decisions changing.
 tags:
   - Spec
   - Augment-It
@@ -197,37 +200,54 @@ Raw capture, tagged by failure shape. The seed data for the audit.
 Scaffold — one entry per federated surface. Fill as we walk each. `needs-audit`
 means no deliberate pass yet this session.
 
-- **Shell** (peek-deck / split / cross-remote nav) — `augment-it:navigate`
-  event works but is under-used; remotes don't all expose nav to their natural
-  next step. **Peek/deck position labels are centered rather than anchored to
-  the pane edge** — `.peek-overlay { justify-content: center }` in
-  `shell/src/App.svelte` (legacy from the first cut). See evidence #10,
-  Decision §6. Still `needs-audit` for the rest (discoverability of
-  Deck/Split/Full mode buttons, chat rail framing).
+- **Shell** (peek-flow / split / cross-remote nav) — `augment-it:navigate`
+  event works; **now composite-aware** (Phase 2c+2d): dispatching with a
+  composite-member remoteId sets the composite's active member and focuses
+  the composite slot. ✅ Peek labels anchored at slice's left margin
+  (Phase 2a). ✅ Deck → Flow rename (Phase 1). Still `needs-audit`:
+  hierarchical Flow widget with bubble progress (Phase 4 / Decision §8);
+  chat rail framing.
 - **Record Collector** — the only forward action is a *per-row* `enrich ›`
   button (`enrichRecord()` → `augment-it:enrich-record`, which the shell turns
-  into "open the recordCollector+promptTemplateManager pair"). There is **no
-  set-level forward action**. [Hidden/Mismatched] — the next step is at the
-  wrong grain. **Decision: add "Augment This Set"** (Decisions §4).
-- **Prompt Template Manager** — has the working `augment-it:navigate` (the
-  model others should copy). But in the PTM ⇄ Pack Runner split, **PTM's body
-  stays rendered even when the user has picked Pre-built Pack mode** — both
-  off-mode and on-mode UI compete for the eye. See evidence #9. `needs-audit`
-  for the rest of the surface.
+  into "open the recordCollector+enrichment pair" with packRunner as the
+  default composite member). There is **no set-level forward action** yet.
+  [Hidden/Mismatched] — the next step is at the wrong grain. **Decision: add
+  "Augment This Set"** (Decisions §4, slated for Phase 5).
+- **Prompt Template Manager** — ✅ part of `ENRICHMENT_COMPOSITE` since
+  Phase 2c. Mode UI lives at the shell level (composite slot header); PTM
+  is pure body with no mode awareness. The shared toggle component is the
+  model others should copy when they need a binary in-slot switcher. Has
+  the working `augment-it:navigate` dispatch pattern.
 - **Request Reviewer** — `needs-audit`.
 - **Response Reviewer** — by-record triage view is the strong surface; auto-
   refreshes on `response.created`. Source of the "run a pack = click-to-fire"
-  model that Pack Runner contradicts.
+  model that Pack Runner contradicts (mismatch resolved when Phase 3 ships
+  bundle-as-the-unit semantics).
 - **Enhanced Records List** — promote success banner had a dead primary button
   (fixed). `needs-audit` for the rest of the promote flow.
 - **Chat** — `needs-audit`.
-- **Pack Runner** — items 1–7 above. The most acute surface.
+- **Pack Runner** — ✅ part of `ENRICHMENT_COMPOSITE` since Phase 2c. Mode
+  UI moved to shell. Items 1–7 above (the foundation-dataset failure list)
+  mostly pending — Phase 3 (bundle-first) is the architectural lift that
+  closes #1 (no "run just this pack" path), #2 (cross-surface verb
+  mismatch — bundle becomes the unit), and sets up #4 (live progress) and
+  #5 (path to results) via Run-as-First-Class-Operation Part 4. ✅ #6
+  (sticky Fire + nav button to Response Reviewer). #3 and #7 remain
+  parked (entity-name foot-gun + default-scope).
 
 ## Decisions locked this session
 
-1. **Pack selection stays multi-select; add a `none` button + an "only this"
-   per-pack affordance + a `solo`/"all" pair** mirroring the ROWS section, so
-   narrowing to one pack is one click, not six un-clicks.
+1. **~~Pack selection stays multi-select; add a `none` button + an "only this"
+   per-pack affordance + a `solo`/"all" pair~~** mirroring the ROWS section.
+   **SUPERSEDED 2026-06-01** by Phase 3 of the refactor plan — **bundle-first
+   Pack Runner**. The original call was "conservative on purpose," but
+   reconciling against [[../blueprints/Packs-and-Bundles-Pattern]] showed
+   that polishing a flat 7-pack list cements a model the blueprint says is
+   wrong: the orchestration unit is a **bundle**, not a list of packs. The
+   helpers (`none` / `all` / `solo`) survive — but they operate inside the
+   selected bundle's **roster panel**, where they're conceptually correct,
+   rather than on a universe of all packs. See
+   [[../plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor]] §Phase 3.
 2. **Defaults unchanged** (entity-name + scope) — parked, see Open questions.
 3. **Ship [[../plans/Run-as-First-Class-Operation]] Part 4 properly** rather
    than leaving the by-hand stand-ins: Pack Runner subscribes to `run.updated`
@@ -254,32 +274,44 @@ means no deliberate pass yet this session.
    **small icon-with-tooltip switchers** (one icon for "custom prompt", one
    for "pre-built pack") — replacing the verbose tabs that currently sit at
    the top of both panes. Label/affordance locked by the user (2026-05-28).
-   *Architectural composition is the open detail* (see Open questions): wrap
-   PTM + Pack Runner inside a single `enrichmentSurface` parent remote, vs.
-   keep them as separate remotes that share mode state via the existing
-   `augment-it:enrichment-mode` window event + localStorage.
-6. **Peek-deck position labels anchor to the left margin.** The vertical
+
+   **✅ SHIPPED 2026-06-01 in Phases 2c + 2d.** Architectural composition
+   resolved as **Option C — shell-level composite slot**, not (a) wrapper
+   remote and not (b) shared-state alone. The shell learned about a new
+   concept: a slot that hosts one-of-N remotes based on shared state. The
+   icon-with-tooltip pair lives in `packages/shared-ui` as
+   `ToggleHeader__PromptOrPackage--Icons.svelte`; the shell renders it as
+   the composite slot's header and mounts only the active member. PTM and
+   Pack Runner lost their intra-remote mode state entirely — the shell is
+   the single source of truth for which member is active.
+   **Emergent insight (Phase 2d):** composites must be **peers in the
+   rotation**, not just slots inside pairings. We split `REMOTES` (federated
+   registry) from `ROTATION` (ordered list of slot ids); composites can
+   appear in `ROTATION`, so the in-slot toggle works in Flow, Split, and
+   Full alike. Mechanic: `shell/src/composites.ts` defines
+   `ENRICHMENT_COMPOSITE`; `shell/src/remotes.ts` defines `ROTATION`;
+   `shell/src/App.svelte` walks `ROTATION` via `slotById` + `materializeSlot`.
+6. **Peek-flow position labels anchor to the left margin.** The vertical
    per-pane indicators (e.g. "REQUEST REVIEWER", same for every neighbour)
    move from centered to **anchored at the pane's left margin** — they're
    landmarks, not floating titles. Locked by the user (2026-06-01).
-   Mechanic: change `.peek-overlay { justify-content: center }` to
-   `flex-start` (or equivalent) in `shell/src/App.svelte`; revisit the
-   `padding-top: 1.5rem` so the label sits where the eye expects.
-   Implementation detail: confirm whether left-side and right-side peek
-   neighbours both want the label at the *outer* left edge, or at the
-   *inner* edge (toward the active pane) — call out at build time.
+   **✅ SHIPPED 2026-06-01 (Phase 2a).** `.peek-overlay` switched to
+   `justify-content: flex-start` + `padding-left: 0.75rem`. The
+   left-outer-vs-inner-edge question got a uniform `flex-start` default;
+   the CSS carries a one-line comment flagging the directional re-evaluation
+   for in-browser review if the right-peek's inner-edge label reads wrong.
+   (Renamed from "peek-deck" to "peek-flow" by Decision §7.)
 7. **Rename "Deck" → "Flow" across the shell.** The top-left mode button
    becomes **Flow / Split / Full**. Internal identifier follows the same
-   rename: `LayoutMode = 'peek-flow' | 'co-existence' | 'full'` (or just
-   `'flow'` — implementation detail). Surface area is contained:
-   - `shell/src/App.svelte:199` — UI label `'Deck'` → `'Flow'`.
-   - `shell/src/layout.svelte.ts:15` — type literal `'peek-deck'`; lines
-     28, 32 — `mode: 'peek-deck'` default and `defaultMode`.
-   - Comments in `shell/src/App.svelte` (lines 66, 103, 112) and
-     `shell/src/remotes.ts` (73, 85) and `shell/src/layout.svelte.ts`
-     (6, 19, 20, 99).
-   - Confirm no localStorage key persists `'peek-deck'` (would need a
-     read-old/write-new migration if so). Locked by the user (2026-06-01).
+   rename: `LayoutMode = 'peek-flow' | 'co-existence' | 'full'`. Locked by
+   the user (2026-06-01).
+   **✅ SHIPPED 2026-06-01 (Phase 1).** Type literal, defaults, UI label,
+   and all in-code comments renamed. localStorage *did* persist `'peek-deck'`
+   in `augment-it:shell-layout`; `readStored()` carries a one-line
+   `migrateMode()` that maps the old value on read so existing users keep
+   their layout. The historical context-v doc
+   `Build-the-Shell-Tiling-and-Peek-Deck.md` retains its filename — the
+   doc's identity is its filename.
 8. **Flow is the primary; Split/Full are its layout sub-options;
    progress is bubble-numbered with tooltips.** The flat mode segment
    is restructured into a *hierarchical workflow widget*. Locked
@@ -305,9 +337,13 @@ means no deliberate pass yet this session.
      bubble strip and the peek-labels collapse into one rail — they
      don't both render in the same place.
    - **Implementation note:** the bubble numbers are derived from
-     `REMOTES.findIndex(focused)` — no new data model needed. Step
-     names are `REMOTES[i].label`. Tooltip body could pull from
-     `REMOTES[i].description` (already exists).
+     `ROTATION` (introduced in Phase 2d as the rotation-order peer to
+     `REMOTES`). Step names are `slotById(ROTATION[i]).label` —
+     `composite.label` for composites, `remote.label` otherwise. Tooltip
+     body pulls from `description`. With the `enrichment` composite already
+     a peer in `ROTATION`, the Open question "one bubble or two for
+     enrichment?" resolves naturally: **one bubble**, because PTM and Pack
+     Runner are already collapsed into the composite at the rotation level.
 
 ## Cross-cutting principles (to develop)
 
@@ -359,25 +395,19 @@ its own context-v doc when picked up.
   (to resolve the verb mismatch) or a sweep of the `needs-audit` surfaces?
 - Does the broad audit want to **fork per-surface child specs**, or stay one
   doc with the audit table? (Fork-early discipline if it balloons.)
-- **Enrichment-surface composition (from Decision §5):** is the right shape
-  **(a) a new `enrichmentSurface` wrapper remote** that mounts PTM and Pack
-  Runner as internal views and owns the icon-mode switcher — clean conceptual
-  unit, one tile in the shell — *or* **(b) keep PTM and Pack Runner as
-  separate paired remotes** and have each hide its body when the shared
-  `augment-it:enrichment-mode` says the other mode is active — smaller change,
-  preserves the existing pairing? Either way the visible-mode rule is locked;
-  this is purely *how* to compose it.
+- ~~**Enrichment-surface composition (from Decision §5)**~~ — **RESOLVED
+  2026-06-01** as **Option C — shell-level composite slot.** Neither (a)
+  wrapper remote nor (b) shared-state alone; the shell learned a new
+  concept (a slot that hosts one-of-N remotes). See Decision §5 for the
+  resolution narrative and the shipped mechanic.
 - **Flow widget default position (from Decision §8):** does the bubble strip
   default to **top** (current location, horizontal) or **left-hand column**
-  (vertical rail)? The toggle exists either way; only the default needs
-  picking. Argument for *top*: minimal layout change from today. Argument
-  for *left*: persistent always-visible workflow rail makes "where am I"
-  unmissable, and frees the top chrome for context-bar info.
-- **Enrichment step in the Flow strip:** the `REMOTES` rotation currently
-  has `promptTemplateManager` as a discrete step (#2). With Decision §5
-  unifying PTM ⇄ Pack Runner as one enrichment surface, should the bubble
-  strip render **one "Enrichment" step** that covers both, or two? Two is
-  legacy from before the pair existed; one matches the new mental model.
+  (vertical rail)? The plan defaults to *top* for minimal layout change;
+  the toggle exists either way. Re-open if the eyeball test prefers left.
+- ~~**Enrichment step in the Flow strip**~~ — **RESOLVED 2026-06-01** as
+  **one bubble**, locked by Phase 2d's `ROTATION` shape. The rotation now
+  reads `recordCollector → enrichment → requestReviewer → responseReviewer
+  → enhancedRecordsList`; the bubble strip will derive directly from it.
 
 ## Related
 

--- a/services/social-search/src/bundles.ts
+++ b/services/social-search/src/bundles.ts
@@ -1,0 +1,82 @@
+// Bundles — the orchestration unit for source-bound fan-out. A bundle is
+// a named composition of packs with a default roster; the user fires the
+// bundle, not a list of packs. Per
+// [[../../context-v/blueprints/Packs-and-Bundles-Pattern]]:
+//
+//   - 4-6 default-true packs per bundle (the "common" set for the entity type)
+//   - rest opt-in via roster-override
+//   - one bundle ↔ one user-facing chat verb (chat verb registration comes
+//     from In-App-Chat-v0-0-1; not this file's concern)
+//   - bundle_id rides on every ResponseRecord the bundle's packs produce
+//
+// Public source of truth. Pack Runner duplicates this shape client-side
+// (apps/pack-runner/src/bundles.ts) — matches the same one-file-each
+// convention as packs.ts. If a bundle lands or its roster changes, update
+// both. Future: graduate to packages/bundles/ when a third consumer appears.
+
+export type BundleMember = {
+  pack_id: string;
+  default: boolean;            // true → roster-checked on bundle load
+  pass: 1 | 2;                 // single-pass bundles always 1
+  required: boolean;           // true → bundle reports failure if this pack errors
+};
+
+export type BundleConfig = {
+  bundle_id: string;
+  display_name: string;        // shown in the Pack Runner selector
+  description: string;         // tooltip / subtitle
+  entity_type?: string;        // matches the .common / .nonprofit suffix on chat verbs
+  passes: 1 | 2;               // single-pass for v1
+  members: BundleMember[];
+};
+
+export const PROFILE_BUILDER: BundleConfig = {
+  bundle_id: 'profile-builder',
+  display_name: 'Profile Builder',
+  description: 'Common-five social packs + Wikipedia — for any entity that lives on the public web',
+  passes: 1,
+  members: [
+    { pack_id: 'linkedin-pack',  default: true,  pass: 1, required: false },
+    { pack_id: 'x-pack',         default: true,  pass: 1, required: false },
+    { pack_id: 'bluesky-pack',   default: true,  pass: 1, required: false },
+    { pack_id: 'youtube-pack',   default: true,  pass: 1, required: false },
+    { pack_id: 'wikipedia-pack', default: true,  pass: 1, required: false },
+    { pack_id: 'facebook-pack',  default: false, pass: 1, required: false },
+    { pack_id: 'instagram-pack', default: false, pass: 1, required: false },
+  ],
+};
+
+export const PROFILE_BUILDER_NONPROFIT: BundleConfig = {
+  bundle_id: 'profile-builder.nonprofit',
+  display_name: 'Profile Builder · Nonprofit',
+  description: 'Common-five + Wikipedia, biased for org-shaped entities; nonprofit-specific packs (Candid, ProPublica, IRS 990) opt-in once they ship',
+  entity_type: 'nonprofit',
+  passes: 1,
+  members: [
+    { pack_id: 'linkedin-pack',  default: true,  pass: 1, required: false },
+    { pack_id: 'x-pack',         default: true,  pass: 1, required: false },
+    { pack_id: 'bluesky-pack',   default: true,  pass: 1, required: false },
+    { pack_id: 'youtube-pack',   default: true,  pass: 1, required: false },
+    { pack_id: 'wikipedia-pack', default: true,  pass: 1, required: false },
+    { pack_id: 'facebook-pack',  default: false, pass: 1, required: false },
+    { pack_id: 'instagram-pack', default: false, pass: 1, required: false },
+  ],
+};
+
+export const BUNDLES: Record<string, BundleConfig> = {
+  [PROFILE_BUILDER.bundle_id]: PROFILE_BUILDER,
+  [PROFILE_BUILDER_NONPROFIT.bundle_id]: PROFILE_BUILDER_NONPROFIT,
+};
+
+export const BUNDLE_IDS = Object.keys(BUNDLES);
+
+export function getBundle(bundle_id: string): BundleConfig | undefined {
+  return BUNDLES[bundle_id];
+}
+
+/** Effective pack ids for a bundle, given its default roster and an optional override set. */
+export function effectivePackIds(bundle: BundleConfig, override?: Set<string>): string[] {
+  return bundle.members
+    .filter((m) => (override ? override.has(m.pack_id) : m.default))
+    .map((m) => m.pack_id);
+}

--- a/services/social-search/src/search.ts
+++ b/services/social-search/src/search.ts
@@ -33,6 +33,10 @@ export type SearchInput = {
   // associated with a prompt template; for now we accept whatever the caller
   // passes and fall back to a synthetic id.
   prompt_id?: string;
+  // Optional — the bundle this fan-out belongs to. Lands on every
+  // ResponseRecord produced by this run so Response Reviewer can group by
+  // bundle when it shows results. See bundles.ts.
+  bundle_id?: string;
 };
 
 export type SearchResult = {
@@ -209,7 +213,7 @@ function publishResponse(
       outcome: args.outcome,
       structured: args.structured,
       pack_id: args.pack_id,
-      bundle_id: null,
+      bundle_id: args.bundle_id ?? null,
       pass: null,
     }),
   );

--- a/services/social-search/src/server.ts
+++ b/services/social-search/src/server.ts
@@ -98,6 +98,10 @@ async function main(): Promise<void> {
         entity_name_field?: string;
         // Optional — override every pack's default provider for this fan-out.
         provider_override?: ProviderId;
+        // Optional — the bundle this fan-out belongs to. Rides on every
+        // ResponseRecord produced by this run; lets Response Reviewer group
+        // results by bundle.
+        bundle_id?: string;
       };
       console.log(JSON.stringify({
         level: 'info',
@@ -106,6 +110,7 @@ async function main(): Promise<void> {
         rows: args.row_ids.length,
         record_set_id: args.record_set_id,
         provider_override: args.provider_override ?? null,
+        bundle_id: args.bundle_id ?? null,
       }));
 
       const tasks: Array<() => Promise<unknown>> = [];
@@ -118,6 +123,7 @@ async function main(): Promise<void> {
               record_set_id: args.record_set_id,
               entity_name_field: args.entity_name_field,
               provider_override: args.provider_override,
+              bundle_id: args.bundle_id,
             }).catch((err) => {
               // Per-cell failures don't abort the run. Log and continue.
               console.error(JSON.stringify({


### PR DESCRIPTION
## Summary

Phase 3 of the [Shell UX Coherence refactor](context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md). Reconciles Pack Runner with [[Packs-and-Bundles-Pattern]] — the orchestration unit is a **Bundle**, not a flat list of packs. **Supersedes spec Decision §1** (the original "conservative" call to add `none`/`solo`/`all` helpers to a flat 7-pack list); those helpers survive but now operate *inside* the chosen bundle's roster panel, where they're conceptually correct.

Also: spec doc reconciliation — recorded shipped status on §5, §6, §7 from Phases 0-2d (already merged in #6) and resolved two of the three Open questions.

## What's new on the screen

- **Step 4 — Bundle.** Segmented control of available bundles (`Profile Builder` | `Profile Builder · Nonprofit`); one-line description of the active bundle below.
- **Step 5 — Roster (N/M).** Bundle members with `default: true` packs pre-checked, `opt-in` chip on default-false packs. Bulk helpers: `all`, `none`, `defaults` (revert to bundle's defaults). Per-pack `solo` button next to each row.
- **Fire button** leads with the bundle name: *"Fire Profile Builder on 67 rows"*.

## Under the hood

- `services/social-search/src/bundles.ts` *(NEW)* — `BundleConfig` with members `[{pack_id, default, pass, required}]`; two v1 bundles (single-pass).
- `services/social-search/src/search.ts` — `SearchInput.bundle_id?` threads through `publishResponse` onto every ResponseRecord (replaces hardcoded `null`).
- `services/social-search/src/server.ts` — `pack.fan_out.requested` args accept optional `bundle_id`; logged on start, passed to `runOnePackSearch`. Old call sites continue to work.
- `apps/pack-runner/src/bundles.ts` *(NEW)* — client-side mirror per the existing `packs.ts` duplicate-by-hand convention, with sync-flag comments in both files.
- `apps/pack-runner/src/App.svelte` — dropped hardcoded `PACKS`; new state `activeBundleId` + per-bundle roster overrides. Persisted as `augment-it:pack-runner:bundle-id` and `augment-it:pack-runner:roster-overrides:<bundle_id>`. Switching bundles restores that bundle's own override or its defaults.
- `apps/pack-runner/src/app.css` — bundle-picker pill row, pack-row layout for the solo button, opt-in chip.

## Spec reconciliation (separate commit)

`context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md` v0.0.0.1 → v0.0.0.2:

- §1 — **SUPERSEDED** by this PR's Phase 3 work; helpers reframed as roster-overrides inside a bundle.
- §5 — ✅ SHIPPED in #6 (Phases 2c+2d); composition resolved as **Option C** (shell-level composite slot); composites are peers in `ROTATION`.
- §6 — ✅ SHIPPED in #6 (Phase 2a); peek labels anchor left.
- §7 — ✅ SHIPPED in #6 (Phase 1); Deck → Flow with localStorage migration.
- Open questions: composition (resolved); one-bubble-or-two for enrichment (resolved as one, by `ROTATION` shape). Flow widget default position (top vs left rail) still open — defaulted to top in the plan.

## Deferred to follow-up plans

These the bundle blueprint defines but this PR doesn't ship:

- Two-pass orchestration with carry-forward between passes
- Pre-flight `profiles.dedup.scan`
- Bundle-level render strategy in Response Reviewer (group-by-bundle is now *possible* because every ResponseRecord carries `bundle_id`, but the grouped view itself is its own work)
- Chat verb registration (`profile-builder` as a one-shot chat verb)

## Verification

- `pnpm build` clean in `apps/pack-runner/`.
- `pnpm typecheck` (tsc --noEmit) clean in `services/social-search/`.

## Test plan

- [ ] Pack Runner shows the **Bundle** picker with two bundles; switching highlights the active one and updates the description line.
- [ ] **Roster** reflects the active bundle's defaults — Profile Builder shows five checked + Facebook/Instagram unchecked-with-opt-in chip.
- [ ] `all` / `none` / `defaults` / per-row `solo` all mutate the visible roster.
- [ ] Switching bundles preserves each bundle's roster overrides independently (toggle Profile Builder roster, switch to Nonprofit, switch back — original overrides intact).
- [ ] **Fire** button reads `Fire <bundle.display_name> on N rows`.
- [ ] Fire actually runs; new ResponseRecords carry the `bundle_id` (verify via Response Reviewer / response-store query).
- [ ] localStorage: refresh — active bundle id and roster overrides persist.

## Related

- Spec: `context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md` §1 (SUPERSEDED)
- Plan: `context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md` §Phase 3
- Blueprint: `context-v/blueprints/Packs-and-Bundles-Pattern.md` §Bundle anatomy
- Previous merged PR (Phases 0-2d): #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)