### PR TITLE
Hierarchical Flow widget (Phase 4) — parent label + bubble progress + Split/Full icons + position toggle

### DIFF
--- a/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
+++ b/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
@@ -420,7 +420,7 @@ a new `enrichmentSurface` remote — depends on it.
 | 2c — Composite slot + shared toggle | ✅ | b9b99df | resolves the spike |
 | 2d — Composites are peers in Flow rotation | ⏳ | — | ROTATION peer to REMOTES; in-slot toggle works in Flow & Full too |
 | 3 — Bundle-first Pack Runner | ✅ | 126a534 | supersedes spec §1 helpers; on feat/bundle-first-pack-runner |
-| 4 — Flow widget | ⏳ | — | |
+| 4 — Flow widget | ⏳→✅ | feat/hierarchical-flow-widget | parent Flow + bubble strip + Split/Full icons + top/left position toggle |
 | 5 — Augment This Set + key unification | ⏳ | — | gated on spike |
 | 6 — Principles + audit harvest | ⏳ | — | |
 | Spike — enrichment composition | ✅ | — | resolved as Option C (composite slot), Phase 2c is the landing |

--- a/shell/src/App.svelte
+++ b/shell/src/App.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import ModeToggle from './ModeToggle.svelte';
   import MountHost from './MountHost.svelte';
+  import FlowWidget from './FlowWidget.svelte';
   import ToggleHeader from '@augment-it/shared-ui/ToggleHeader__PromptOrPackage--Icons.svelte';
   import {
     ROTATION,
@@ -305,12 +306,6 @@
     };
   });
 
-  const MODE_BUTTONS: { mode: LayoutMode; label: string }[] = [
-    { mode: 'peek-flow', label: 'Flow' },
-    { mode: 'co-existence', label: 'Split' },
-    { mode: 'full', label: 'Full' },
-  ];
-
   function selectMode(mode: LayoutMode): void {
     if (mode === 'co-existence') {
       const pairing = PAIRINGS[0];
@@ -318,6 +313,22 @@
     } else {
       layout.setMode(mode);
     }
+  }
+
+  // Click a bubble in the Flow widget — navigate to that rotation step.
+  // In peek-flow we just move focusIndex; in co-existence / full we move
+  // focusIndex AND drop back to peek-flow (the user picked a step, not a
+  // pairing). Matches the augment-it:navigate handler's behaviour when the
+  // caller doesn't request a specific mode.
+  function selectStep(slotId: string): void {
+    const idx = ROTATION.findIndex((id) => id === slotId);
+    if (idx < 0) return;
+    layout.setFocusIndex(idx);
+    if (layout.mode !== 'peek-flow') layout.setMode('peek-flow');
+  }
+
+  function toggleFlowWidgetPosition(): void {
+    layout.setFlowWidgetPosition(layout.flowWidgetPosition === 'top' ? 'left' : 'top');
   }
 
   const showSplitter = $derived(layout.mode === 'co-existence' && stage.length === 2);
@@ -328,13 +339,18 @@
     <strong>augment-it</strong>
     <span class="muted">· shell</span>
   </div>
-  <nav>
-    {#each MODE_BUTTONS as b (b.mode)}
-      <button class:active={layout.mode === b.mode} onclick={() => selectMode(b.mode)}>
-        {b.label}
-      </button>
-    {/each}
-  </nav>
+  {#if layout.flowWidgetPosition === 'top'}
+    <FlowWidget
+      activeIndex={layout.focusIndex}
+      mode={layout.mode}
+      orientation="top"
+      onSelectStep={selectStep}
+      onSelectMode={selectMode}
+      onTogglePosition={toggleFlowWidgetPosition}
+    />
+  {:else}
+    <div class="header-flow-placeholder" aria-hidden="true"></div>
+  {/if}
   <div class="metrics">
     <button
       class="chat-toggle"
@@ -350,7 +366,19 @@
   </div>
 </header>
 
-<div class="below-header" class:has-chat={chatVisible}>
+<div class="below-header" class:has-chat={chatVisible} class:has-flow-rail={layout.flowWidgetPosition === 'left'}>
+  {#if layout.flowWidgetPosition === 'left'}
+    <aside class="flow-rail" aria-label="Workflow rail">
+      <FlowWidget
+        activeIndex={layout.focusIndex}
+        mode={layout.mode}
+        orientation="left"
+        onSelectStep={selectStep}
+        onSelectMode={selectMode}
+        onTogglePosition={toggleFlowWidgetPosition}
+      />
+    </aside>
+  {/if}
   {#if chatVisible}
     <aside class="chat-rail" aria-label="Chat panel">
       <MountHost remote={CHAT_REMOTE} />
@@ -386,7 +414,11 @@
       {#if !isInteractive}
         <!-- peek neighbour: a click-capture overlay. Hover expands it,
              click commits it as the new focus. The live app underneath is
-             not interactive while it is a neighbour. -->
+             not interactive while it is a neighbour.
+             When the Flow widget is on the left rail, the bubble strip
+             carries the "where am I" information, so we hide the per-slot
+             label here to avoid double-rendering it (spec §8 coherence
+             with §6 — same information, two locations is silly). -->
         <button
           class="peek-overlay"
           aria-label={`Focus ${item.label}`}
@@ -394,7 +426,9 @@
           onmouseleave={() => (hoveredNeighborId = null)}
           onclick={() => commitFocus(item.id)}
         >
-          <span class="peek-label">{item.label}</span>
+          {#if layout.flowWidgetPosition !== 'left'}
+            <span class="peek-label">{item.label}</span>
+          {/if}
         </button>
       {/if}
 
@@ -442,22 +476,7 @@
   }
   .brand strong { color: var(--color-accent); font-size: 1.05rem; }
   .brand .muted { color: var(--color-text-muted); }
-  nav { display: flex; gap: 0.5rem; }
-  nav button {
-    background: transparent;
-    color: var(--color-text);
-    border: 1px solid var(--color-border);
-    padding: 4px 12px;
-    border-radius: 4px;
-    font: inherit;
-    cursor: pointer;
-  }
-  nav button:hover { border-color: var(--color-accent); }
-  nav button.active {
-    background: var(--color-selected-tint);
-    border-color: var(--color-accent);
-    color: var(--color-accent);
-  }
+  .header-flow-placeholder { /* keeps the grid columns even when widget is on left rail */ }
   .metrics { display: flex; gap: 0.75rem; align-items: center; font-size: 11px; }
   .muted { color: var(--color-text-muted); }
 
@@ -497,6 +516,18 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
+  }
+  /* Flow widget when positioned as a left rail (spec §8 + Phase 4).
+     Persistent vertical workflow indicator; sits outside the chat-rail
+     so the order is: flow-rail | chat-rail | stage. */
+  .flow-rail {
+    width: 64px;
+    flex-shrink: 0;
+    border-right: 1px solid var(--color-border);
+    background: var(--color-surface-raised, var(--color-background));
+    overflow: hidden;
+    display: flex;
+    justify-content: center;
   }
 
   /* ---- the tiling stage ---- */

--- a/shell/src/FlowWidget.svelte
+++ b/shell/src/FlowWidget.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+  /**
+   * Hierarchical Flow widget (spec Decision §8 / Phase 4).
+   *
+   * Three tiers:
+   *  1. Parent label "Flow" — raised above the rest.
+   *  2. Numbered bubble progress strip — one bubble per ROTATION step,
+   *     active bubble highlighted, click navigates, hover shows tooltip
+   *     with the step's label + description.
+   *  3. Layout sub-options — Split / Full as small icon-with-tooltip
+   *     toggles (peek-flow is the implicit "Flow" mode and isn't a button
+   *     here; clicking the parent "Flow" label exits Split/Full back to
+   *     peek-flow).
+   *
+   * Position toggle: the widget renders horizontally at the top (default)
+   * or vertically as a left rail. The owning App.svelte places the widget
+   * in the right slot and passes `orientation`; the widget renders the
+   * same content in both directions.
+   *
+   * Pure presentation: receives `steps`, `activeIndex`, `mode`, the
+   * `orientation`, and callbacks. Owns no state.
+   */
+
+  import { ROTATION, slotById, type Slot } from './remotes';
+  import type { LayoutMode, FlowWidgetPosition } from './layout.svelte';
+
+  type Step = {
+    id: string;          // ROTATION slot id
+    label: string;       // slot.label (composite.label or remote.label)
+    description: string; // slot.description
+  };
+
+  let {
+    activeIndex,
+    mode,
+    orientation,
+    onSelectStep,
+    onSelectMode,
+    onTogglePosition,
+  }: {
+    activeIndex: number;
+    mode: LayoutMode;
+    orientation: FlowWidgetPosition;
+    onSelectStep: (slotId: string) => void;
+    onSelectMode: (mode: LayoutMode) => void;
+    onTogglePosition: () => void;
+  } = $props();
+
+  // Derive steps from ROTATION via slotById. composites expose label and
+  // description directly; remotes expose them through remote.
+  const steps: Step[] = ROTATION.map((id) => {
+    const slot = slotById(id);
+    if (!slot) return { id, label: id, description: '' };
+    if (slot.kind === 'remote') {
+      return { id, label: slot.remote.label, description: slot.remote.description };
+    }
+    return { id, label: slot.composite.label, description: slot.composite.description };
+  });
+</script>
+
+<div class="flow-widget" class:orientation-top={orientation === 'top'} class:orientation-left={orientation === 'left'}>
+  <button
+    type="button"
+    class="flow-parent"
+    class:active={mode === 'peek-flow'}
+    title="Flow — left-to-right workflow across the rotation"
+    onclick={() => onSelectMode('peek-flow')}
+  >
+    Flow
+  </button>
+
+  <ol class="bubble-strip" aria-label="Workflow steps">
+    {#each steps as step, i (step.id)}
+      <li>
+        <button
+          type="button"
+          class="bubble"
+          class:active={i === activeIndex}
+          aria-current={i === activeIndex ? 'step' : undefined}
+          title={`${step.label}${step.description ? ' — ' + step.description : ''}`}
+          onclick={() => onSelectStep(step.id)}
+        >
+          <span class="bubble-num">{i + 1}</span>
+        </button>
+      </li>
+    {/each}
+  </ol>
+
+  <div class="layout-toggles" role="tablist" aria-label="Layout sub-option">
+    <button
+      type="button"
+      class="layout-toggle"
+      class:active={mode === 'co-existence'}
+      role="tab"
+      aria-selected={mode === 'co-existence'}
+      aria-label="Split — two cooperating panes"
+      title="Split — two cooperating panes"
+      onclick={() => onSelectMode('co-existence')}
+    >
+      <span aria-hidden="true">⊟</span>
+    </button>
+    <button
+      type="button"
+      class="layout-toggle"
+      class:active={mode === 'full'}
+      role="tab"
+      aria-selected={mode === 'full'}
+      aria-label="Full — one pane, full bleed"
+      title="Full — one pane, full bleed"
+      onclick={() => onSelectMode('full')}
+    >
+      <span aria-hidden="true">▢</span>
+    </button>
+  </div>
+
+  <button
+    type="button"
+    class="position-toggle"
+    aria-label={orientation === 'top' ? 'Move Flow widget to left rail' : 'Move Flow widget to top'}
+    title={orientation === 'top' ? 'Move to left rail' : 'Move to top'}
+    onclick={onTogglePosition}
+  >
+    <span aria-hidden="true">{orientation === 'top' ? '⇲' : '⇱'}</span>
+  </button>
+</div>
+
+<style>
+  .flow-widget {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--color-text);
+  }
+  .orientation-left {
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1rem 0.5rem;
+    align-items: center;
+  }
+
+  .flow-parent {
+    background: transparent;
+    color: var(--color-accent);
+    border: 0;
+    padding: 0;
+    font: inherit;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    text-transform: uppercase;
+  }
+  .flow-parent:hover { color: var(--color-text); }
+  .flow-parent.active {
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 4px;
+  }
+
+  /* Bubble progress strip */
+  .bubble-strip {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .orientation-left .bubble-strip {
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+  .bubble {
+    background: transparent;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    border-radius: 999px;
+    font: inherit;
+    font-size: 0.75rem;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: border-color 0.12s ease, color 0.12s ease;
+  }
+  .bubble:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+  .bubble.active {
+    background: var(--color-accent);
+    color: var(--color-on-accent);
+    border-color: var(--color-accent);
+    cursor: default;
+  }
+
+  /* Split / Full icon toggles */
+  .layout-toggles {
+    display: flex;
+    gap: 0.3rem;
+  }
+  .orientation-left .layout-toggles {
+    flex-direction: column;
+  }
+  .layout-toggle {
+    background: transparent;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+    width: 1.6rem;
+    height: 1.6rem;
+    padding: 0;
+    border-radius: 4px;
+    font: inherit;
+    font-size: 0.95rem;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+  }
+  .layout-toggle:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+  .layout-toggle.active {
+    background: var(--color-accent);
+    color: var(--color-on-accent);
+    border-color: var(--color-accent);
+    cursor: default;
+  }
+
+  .position-toggle {
+    background: transparent;
+    border: 0;
+    color: var(--color-text-muted);
+    padding: 0.2rem 0.3rem;
+    cursor: pointer;
+    font-size: 0.95rem;
+    line-height: 1;
+    border-radius: 4px;
+  }
+  .position-toggle:hover { color: var(--color-accent); }
+</style>

--- a/shell/src/layout.svelte.ts
+++ b/shell/src/layout.svelte.ts
@@ -14,12 +14,15 @@ import { ROTATION, PAIRINGS } from './remotes';
 
 export type LayoutMode = 'peek-flow' | 'co-existence' | 'full';
 
+export type FlowWidgetPosition = 'top' | 'left';
+
 export type ShellLayoutPreference = {
   mode: LayoutMode;
   focusIndex: number;                       // peek-flow / full: position in REMOTES
   focusedWidthPct: number;                  // peek-flow: user-adjusted focused width
   coExistenceRatios: Record<string, number>; // pair key → left-panel %
   defaultMode: LayoutMode;
+  flowWidgetPosition: FlowWidgetPosition;   // where the Flow widget renders (Phase 4)
 };
 
 const STORAGE_KEY = 'augment-it:shell-layout';
@@ -30,6 +33,7 @@ const DEFAULTS: ShellLayoutPreference = {
   focusedWidthPct: 90,
   coExistenceRatios: {},
   defaultMode: 'peek-flow',
+  flowWidgetPosition: 'top',
 };
 
 // One-time migration for the Deck → Flow rename (spec Decision §7).
@@ -73,6 +77,7 @@ class ShellLayout {
   focusedWidthPct: number;
   coExistenceRatios: Record<string, number>;
   defaultMode: LayoutMode;
+  flowWidgetPosition: FlowWidgetPosition;
   activePairKey: string | null; // co-existence: which pairing is showing
 
   constructor() {
@@ -82,6 +87,7 @@ class ShellLayout {
     this.focusedWidthPct = $state<number>(clamp(p.focusedWidthPct, FOCUSED_WIDTH_MIN, FOCUSED_WIDTH_MAX));
     this.coExistenceRatios = $state<Record<string, number>>(p.coExistenceRatios);
     this.defaultMode = $state<LayoutMode>(p.defaultMode);
+    this.flowWidgetPosition = $state<FlowWidgetPosition>(p.flowWidgetPosition);
     this.activePairKey = $state<string | null>(PAIRINGS[0]?.key ?? null);
   }
 
@@ -93,12 +99,18 @@ class ShellLayout {
       focusedWidthPct: this.focusedWidthPct,
       coExistenceRatios: { ...this.coExistenceRatios },
       defaultMode: this.defaultMode,
+      flowWidgetPosition: this.flowWidgetPosition,
     };
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
     } catch {
       // storage disabled — layout still works for the session
     }
+  }
+
+  setFlowWidgetPosition(p: FlowWidgetPosition): void {
+    this.flowWidgetPosition = p;
+    this.persist();
   }
 
   setMode(mode: LayoutMode): void {


### PR DESCRIPTION
## Summary

Phase 4 of the [Shell UX Coherence refactor](context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md). Replaces the flat **Flow / Split / Full** segment in the header with a three-tier hierarchical widget that makes the workflow itself visible, and lets the user park the widget either at the top (current location) or on a left rail (persistent vertical workflow rail).

Implements spec **Decision §8**.

## What's new on the screen

- **Tier 1 — parent label.** A larger, accent-colored **Flow** wordmark. Clicking it returns to peek-flow from Split or Full.
- **Tier 2 — bubble progress strip.** Numbered bubbles `① → ② → ③ → ④ → ⑤`, one per `ROTATION` step (Record Collector, Enrichment, Request Reviewer, Response Reviewer, Enhanced Records). Active bubble highlighted. Hover for the step's label + description; click to navigate. The Enrichment composite renders as **one** bubble, not two — locked by the `ROTATION` shape from Phase 2d.
- **Tier 3 — Split / Full as icon-with-tooltip toggles** (⊟ and ▢), beneath the bubble strip. Same icon pattern Phase 2c established for enrichment.
- **Position toggle** — a small chevron on the widget swaps it between top (horizontal) and left-rail (vertical). The choice persists in `localStorage`.

## Coherence with prior phases

- **§6 peek labels:** when the widget is on the left rail, the bubble strip already shows "where am I." The per-slot peek label is hidden to avoid double-rendering the same information.
- **§5 composite slot:** the bubble for Enrichment uses `slotById(ROTATION[i]).label` → `composite.label` ("Enrichment"), tooltip → `composite.description`. The same `ROTATION` walking that the rest of the shell uses.
- **§7 Flow rename:** the parent label is "Flow" because the whole refactor reframes the mode as a left-to-right workflow.

## Under the hood

- `shell/src/FlowWidget.svelte` *(NEW)* — pure presentation component, receives `{ activeIndex, mode, orientation, onSelectStep, onSelectMode, onTogglePosition }`. Renders the same content vertically when `orientation === 'left'`.
- `shell/src/layout.svelte.ts` — `ShellLayoutPreference.flowWidgetPosition: 'top' | 'left'` (default `'top'`), persisted in `augment-it:shell-layout`. `setFlowWidgetPosition()` helper.
- `shell/src/App.svelte` — dropped the `MODE_BUTTONS` array and the inline `<nav>`. Header renders `<FlowWidget orientation="top"/>` when position is top; a placeholder cell keeps the three-column grid balanced when on left. A new `<aside class="flow-rail">` (64px wide) sits before the chat-rail when position is left.
  - New handlers: `selectStep(slotId)` — sets focusIndex from `ROTATION` and drops back to peek-flow when called from Split/Full (matches the `augment-it:navigate` semantics). `toggleFlowWidgetPosition()` swaps and persists.
  - Click-capture peek-overlay still works in left mode; only the duplicate label is hidden.

## Default position

Per the plan's call: **top** (minimal layout disruption from before). The toggle exists either way; revisit the default if left-rail proves more usable in practice.

## Verification

- `pnpm build` clean in `shell/`.

## Test plan

- [ ] Flow widget appears in the header by default: parent **Flow** label, five numbered bubbles, two icon toggles.
- [ ] Bubble #1 highlights when on Record Collector; click bubble #3 → focus moves to Request Reviewer.
- [ ] Hover a bubble → tooltip reads the step's label + description.
- [ ] Click ⊟ → enters Split (co-existence). The Split icon highlights; bubble strip still shows current rotation slot.
- [ ] Click the **Flow** parent label → returns to peek-flow.
- [ ] Click the chevron → widget moves to a 64px left rail; peek-overlay labels disappear from the slices (single source of truth for "where am I").
- [ ] Click the chevron again → widget returns to the top.
- [ ] Reload → position persists.

## Related

- Spec: `context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md` §8
- Plan: `context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md` §Phase 4
- Prior PRs: #6 (Phases 0-2d), #7 (Phase 3 — bundle-first Pack Runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)