### PR TITLE
Augment This Set (Phase 5) — set-level forward action + record-set key unification

### DIFF
--- a/apps/pack-runner/src/App.svelte
+++ b/apps/pack-runner/src/App.svelte
@@ -9,7 +9,15 @@
   // Remember the user's last record-set + column picks so re-entry doesn't
   // require re-selecting everything. Keys keep the augment-it prefix per
   // the existing localStorage convention.
-  const RECORD_SET_KEY = 'augment-it:pack-runner:record-set';
+  //
+  // The active record set is now stored under the workspace-canonical key
+  // `augment-it:active-record-set` (Phase 5) — one write pre-selects this
+  // set for any surface that reads it, including the Record Collector
+  // "Augment This Set" hand-off. We still read the legacy
+  // `augment-it:pack-runner:record-set` as a fallback for pre-Phase-5
+  // sessions, then write canonical on every change going forward.
+  const ACTIVE_RECORD_SET_KEY = 'augment-it:active-record-set';
+  const LEGACY_RECORD_SET_KEY = 'augment-it:pack-runner:record-set';
   const ENTITY_FIELD_KEY = 'augment-it:pack-runner:entity-name-field';
   // Bundle-aware persistence (Phase 3): the active bundle id, plus per-bundle
   // roster-override sets so swapping bundles doesn't lose user tuning per bundle.
@@ -54,7 +62,9 @@
 
   let status = $state<'connecting' | 'open' | 'closed' | 'error'>('connecting');
   let recordSets = $state<RecordSet[]>([]);
-  let selectedRecordSetId = $state<string | null>(readStored(RECORD_SET_KEY));
+  let selectedRecordSetId = $state<string | null>(
+    readStored(ACTIVE_RECORD_SET_KEY) ?? readStored(LEGACY_RECORD_SET_KEY),
+  );
   let rowsForSelected = $state<Row[]>([]);
   let selectedRowIds = $state<Set<string>>(new Set());
   let entityNameField = $state<string>(readStored(ENTITY_FIELD_KEY) ?? '');
@@ -128,6 +138,21 @@
       onStatus: (s) => (status = s),
     });
     void loadRecordSets();
+
+    // Listen for the canonical-key change so an "Augment This Set" click
+    // from Record Collector re-targets us even when we're already mounted.
+    // Same pattern as the composite mode broadcast (shell/src/composites.ts).
+    const onActiveRecordSetChange = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { record_set_id?: string } | undefined;
+      const next = detail?.record_set_id;
+      if (next && next !== selectedRecordSetId) {
+        void selectRecordSet(next);
+      }
+    };
+    window.addEventListener('augment-it:active-record-set-changed', onActiveRecordSetChange);
+    return () => {
+      window.removeEventListener('augment-it:active-record-set-changed', onActiveRecordSetChange);
+    };
   });
 
   async function loadRecordSets() {
@@ -147,9 +172,10 @@
       if (restoredId) {
         await selectRecordSet(restoredId);
       } else if (selectedRecordSetId) {
-        // Stored id is stale (set was deleted/archived). Clear the persistence.
+        // Stored id is stale (set was deleted/archived). Clear both keys.
         selectedRecordSetId = null;
-        writeStored(RECORD_SET_KEY, null);
+        writeStored(ACTIVE_RECORD_SET_KEY, null);
+        writeStored(LEGACY_RECORD_SET_KEY, null);
       }
     } catch (err: unknown) {
       console.error('record_set.list', err);
@@ -158,7 +184,7 @@
 
   async function selectRecordSet(record_set_id: string) {
     selectedRecordSetId = record_set_id;
-    writeStored(RECORD_SET_KEY, record_set_id);
+    writeStored(ACTIVE_RECORD_SET_KEY, record_set_id);
     rowsForSelected = [];
     selectedRowIds = new Set();
     try {

--- a/apps/record-collector/src/App.svelte
+++ b/apps/record-collector/src/App.svelte
@@ -108,6 +108,39 @@
     );
   }
 
+  // Set-level enrichment — spec Decision §4. The user's mental model on
+  // landing here is "I picked this record set; now augment it." The
+  // single-record `enrich ›` button is at the wrong grain for that
+  // intent. This button takes the whole selected set to Enrichment.
+  //
+  // Mechanic:
+  //   1. Write the canonical 'augment-it:active-record-set' key (Phase 5).
+  //      Pack Runner reads it and a follow-up surface (PTM) will too.
+  //   2. Broadcast 'augment-it:active-record-set-changed' so any already-
+  //      mounted consumer re-targets without remounting.
+  //   3. Dispatch augment-it:navigate to the 'enrichment' composite slot.
+  //      The composite's last-active member (Pack Runner by default) is
+  //      what mounts; the user toggles in-slot if they want PTM instead.
+  const ACTIVE_RECORD_SET_KEY = 'augment-it:active-record-set';
+  function augmentThisSet(rs: RecordSet) {
+    try {
+      localStorage.setItem(ACTIVE_RECORD_SET_KEY, rs.record_set_id);
+    } catch {
+      // localStorage unavailable — the navigate still works, the
+      // downstream surface just won't have the record set pre-selected.
+    }
+    window.dispatchEvent(
+      new CustomEvent('augment-it:active-record-set-changed', {
+        detail: { record_set_id: rs.record_set_id },
+      }),
+    );
+    window.dispatchEvent(
+      new CustomEvent('augment-it:navigate', {
+        detail: { remoteId: 'enrichment' },
+      }),
+    );
+  }
+
   async function deleteRecordSet(rs: RecordSet) {
     const confirmed = window.confirm(
       `Delete "${rs.name}" and its ${rs.row_ids.length} row${rs.row_ids.length === 1 ? '' : 's'}? This cannot be undone.`,
@@ -218,7 +251,14 @@
     {#if !selectedRs}
       <p class="muted">(pick a record set)</p>
     {:else}
-      <h3>{selectedRs.name}</h3>
+      <div class="set-header">
+        <h3>{selectedRs.name}</h3>
+        <button
+          class="augment-this-set"
+          title="Take the whole set to Enrichment — Pack Runner or Prompt Templates (toggle in-slot)"
+          onclick={() => augmentThisSet(selectedRs)}
+        >Augment This Set →</button>
+      </div>
       <div class="rows-list">
         {#each rowsForSelected as row (row.row_id)}
           {@const orderedFields = selectedRs.schema.fields

--- a/apps/record-collector/src/app.css
+++ b/apps/record-collector/src/app.css
@@ -28,6 +28,33 @@
   color: var(--color-accent-2);
 }
 
+/* Set-level header — name + primary "Augment This Set" CTA side by side
+   (spec Decision §4). The button is the set-grain forward action; the
+   per-row `enrich ›` still works for one-off enrichment. */
+.rc-app .set-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.6rem;
+}
+.rc-app .set-header h3 { margin: 0; }
+.rc-app .augment-this-set {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  border: 1px solid var(--color-accent);
+  padding: 0.4rem 0.85rem;
+  border-radius: 4px;
+  font: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+.rc-app .augment-this-set:hover {
+  filter: brightness(1.08);
+}
+
 .rc-app .muted {
   color: var(--color-text-muted);
 }

--- a/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
+++ b/context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md
@@ -421,7 +421,7 @@ a new `enrichmentSurface` remote — depends on it.
 | 2d — Composites are peers in Flow rotation | ⏳ | — | ROTATION peer to REMOTES; in-slot toggle works in Flow & Full too |
 | 3 — Bundle-first Pack Runner | ✅ | 126a534 | supersedes spec §1 helpers; on feat/bundle-first-pack-runner |
 | 4 — Flow widget | ⏳→✅ | feat/hierarchical-flow-widget | parent Flow + bubble strip + Split/Full icons + top/left position toggle |
-| 5 — Augment This Set + key unification | ⏳ | — | gated on spike |
+| 5 — Augment This Set + key unification | ⏳→✅ | feat/augment-this-set | spike resolved in 2c; canonical key 'augment-it:active-record-set' + RC button |
 | 6 — Principles + audit harvest | ⏳ | — | |
 | Spike — enrichment composition | ✅ | — | resolved as Option C (composite slot), Phase 2c is the landing |
 


### PR DESCRIPTION
## Summary

Phase 5 of the [Shell UX Coherence refactor](context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md). Implements spec **Decision §4**.

The user's mental model when they've just picked a record set in Record Collector is *"I picked this set; now augment it."* Today the only forward action is a per-row `enrich ›` button — the wrong grain. This PR adds a prominent **Augment This Set →** button next to the selected set's name. Clicking it lands the user in the Enrichment composite (Pack Runner by default; user can toggle to Custom Prompt in-slot) with the record set already pre-selected.

To make "already pre-selected" work without a per-pair localStorage key dance, this PR also introduces the canonical key `augment-it:active-record-set` — one write pre-selects this set for any surface that reads it.

Two commits, intentionally separated:

- `7e92993` — Pack Runner reads the canonical key (with legacy-key fallback for migration) + listens for `augment-it:active-record-set-changed` so an already-mounted Pack Runner re-targets cleanly. No visible UX change.
- `5540f1f` — Record Collector grows the **Augment This Set →** button + handler that writes the canonical key, broadcasts the change, and dispatches `augment-it:navigate` to the `enrichment` composite slot.

## What's new on the screen

- **Record Collector** — once you pick a record set, a prominent accent-colored **Augment This Set →** button sits next to the set's name. Click → lands on the Enrichment slot in the shell with the set ready to fire.
- The per-row `enrich ›` button is unchanged; it remains the one-record-at-a-time path.

## Under the hood

### Pack Runner — `apps/pack-runner/src/App.svelte`

- New constants: `ACTIVE_RECORD_SET_KEY = 'augment-it:active-record-set'` (canonical), `LEGACY_RECORD_SET_KEY = 'augment-it:pack-runner:record-set'` (back-compat fallback).
- On mount: read canonical first, fall back to legacy. Going forward `selectRecordSet` only writes the canonical key; stale-id cleanup wipes both.
- `window.addEventListener('augment-it:active-record-set-changed', …)` so an external writer (Record Collector) re-targets even when Pack Runner is already mounted inside the composite slot. Same broadcast pattern `shell/src/composites.ts` uses for the enrichment-mode flip.

### Record Collector — `apps/record-collector/src/App.svelte` + `app.css`

- New `augmentThisSet(rs)` handler:
  1. `localStorage.setItem('augment-it:active-record-set', rs.record_set_id)`
  2. `window.dispatchEvent('augment-it:active-record-set-changed', { record_set_id })`
  3. `window.dispatchEvent('augment-it:navigate', { remoteId: 'enrichment' })`

  The shell's nav handler (added in Phase 2d) walks `ROTATION` first, finds `enrichment`, and focuses that slot. The composite's last-active member is what mounts (default `packRunner`). The user toggles to Custom Prompt in-slot if they want PTM instead.
- New `.set-header` flex layout with accent-fill **Augment This Set →** CTA.

## Coherence

Per spec Decision §5 (composite slot), the user toggles `Custom Prompt ⇄ Pre-built Pack` *inside* the slot. Per Decision §4, set-level intent lands at the slot, not at one of two pre-decided remotes. The two decisions compose cleanly: one button per intent (whole set vs one row), at the right grain.

PTM doesn't currently bind to a record set, so the "unification" is asymmetric today: Pack Runner reads the canonical key; PTM is unchanged. When PTM grows record-set awareness it'll read the same canonical key — that's the seam already established here.

## Verification

- `pnpm build` clean in `apps/record-collector/` and `apps/pack-runner/`.

## Test plan

- [ ] In Record Collector, pick a record set. **Augment This Set →** appears next to the set name, accent-colored.
- [ ] Click → shell focuses the Enrichment slot. The Pack Runner pane (default composite member) shows the set already selected; rows auto-load.
- [ ] Pre-test: ensure Pack Runner shows the right set even when *already mounted* (e.g. previously on Enrichment, navigated away to Response Reviewer, returned via Augment-This-Set on a different record set).
- [ ] Reload → canonical key persists; Pack Runner re-restores it on mount.
- [ ] Toggle the in-slot ✎/⊞ to Custom Prompt → PTM mounts (no record-set awareness yet; that's a future PR).
- [ ] Pre-Phase-5 sessions: the legacy `augment-it:pack-runner:record-set` is still honored on first mount.

## Related

- Spec: `context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md` §4
- Plan: `context-v/plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor.md` §Phase 5
- Prior PRs: #6 (Phases 0-2d), #7 (Phase 3 bundle-first Pack Runner), #8 (Phase 4 hierarchical Flow widget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)