### PR TITLE
Pack Runner surfaces its target, infers its inputs (Decision §9)

### DIFF
--- a/apps/pack-runner/src/App.svelte
+++ b/apps/pack-runner/src/App.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { workspace, type RecordSet, type Row } from '@augment-it/workspace';
-  import { BUNDLES, getBundle, packDisplayName, type BundleConfig } from './bundles';
+  import { BUNDLES, getBundle, packDisplayName, inferEntityNameField, type BundleConfig } from './bundles';
 
   const TOKEN_KEY = 'augment-it:session-token';
   const WS_URL = 'ws://localhost:3001/ws';
@@ -18,7 +18,12 @@
   // sessions, then write canonical on every change going forward.
   const ACTIVE_RECORD_SET_KEY = 'augment-it:active-record-set';
   const LEGACY_RECORD_SET_KEY = 'augment-it:pack-runner:record-set';
-  const ENTITY_FIELD_KEY = 'augment-it:pack-runner:entity-name-field';
+  // Per-record-set override for the inferred entity-name column (spec
+  // Decision §9). Keyed by record_set_id so overrides don't leak across
+  // sets. The legacy global key is read once as a migration fallback when
+  // no per-set override exists yet.
+  const ENTITY_FIELD_KEY_PREFIX = 'augment-it:entity-name-field:';
+  const LEGACY_ENTITY_FIELD_KEY = 'augment-it:pack-runner:entity-name-field';
   // Bundle-aware persistence (Phase 3): the active bundle id, plus per-bundle
   // roster-override sets so swapping bundles doesn't lose user tuning per bundle.
   const BUNDLE_ID_KEY = 'augment-it:pack-runner:bundle-id';
@@ -67,7 +72,13 @@
   );
   let rowsForSelected = $state<Row[]>([]);
   let selectedRowIds = $state<Set<string>>(new Set());
-  let entityNameField = $state<string>(readStored(ENTITY_FIELD_KEY) ?? '');
+  let entityNameField = $state<string>('');
+  // Whether the user has explicitly picked a different entity-name column
+  // than the inference. Drives the "we're reading entity names from X"
+  // hint vs the dropdown affordance.
+  let entityNameOverridden = $state<boolean>(false);
+  // When the user clicks `change ›`, expose the dropdown inline.
+  let entityNamePickerOpen = $state<boolean>(false);
   let activeBundleId = $state<string>(initialBundle.bundle_id);
   let enabledPackIds = $state<Set<string>>(
     readRoster(initialBundle.bundle_id) ?? defaultRoster(initialBundle),
@@ -80,6 +91,12 @@
   );
   const columns = $derived(selectedSet?.schema.fields.map((f) => f.name) ?? []);
   const activeBundle = $derived(getBundle(activeBundleId) ?? BUNDLES[0]);
+  // Target columns — what gets richer when responses land + are accepted.
+  // For v1 this is always 'socials' (per the 2026-05-25 pivot baked into
+  // services/social-search/src/search.ts). Future bundles whose packs
+  // write to other columns can declare additional targets on the bundle
+  // and we'll render the union. Spec Decision §9.
+  const targetColumns = $derived<string[]>(activeBundle.target_columns ?? ['socials']);
   const enabledPackCount = $derived(enabledPackIds.size);
   const rosterSize = $derived(activeBundle.members.length);
 
@@ -196,30 +213,59 @@
       // checkboxes refine. Avoids the "everything visible but Fire is
       // disabled" trap.
       selectedRowIds = new Set(r.rows.map((row) => row.row_id));
-      // Restore last entity-name-field choice if the column still exists in
-      // this set's schema; otherwise fall back to a best-guess.
-      const stored = readStored(ENTITY_FIELD_KEY);
+      // Entity-name column resolution (spec Decision §9):
+      //   1. Per-record-set override (the explicit pick the user has
+      //      saved for THIS set) wins. Persisted under
+      //      augment-it:entity-name-field:<record_set_id>.
+      //   2. Otherwise infer from the ENTITY_NAME_CANDIDATES list against
+      //      the set's schema field names — first match wins.
+      //   3. Migration fallback: the pre-Phase-§9 global key
+      //      augment-it:pack-runner:entity-name-field is read once if no
+      //      per-set override exists, in case the user had configured it
+      //      manually before. Not written going forward.
+      //   4. Last resort: first column, if any. Hint will say "no match;
+      //      pick a column" — entityNameOverridden stays false so the
+      //      change-link is visible by default.
+      const setOverrideKey = ENTITY_FIELD_KEY_PREFIX + record_set_id;
+      const setOverride = readStored(setOverrideKey);
       const cols = (recordSets.find((rs) => rs.record_set_id === record_set_id)?.schema.fields ?? []).map((f) => f.name);
-      if (stored && cols.includes(stored)) {
-        entityNameField = stored;
+      if (setOverride && cols.includes(setOverride)) {
+        entityNameField = setOverride;
+        entityNameOverridden = true;
       } else {
-        const candidates = ['name', 'organization', 'org', 'company', 'foundation', 'entity'];
-        entityNameField =
-          candidates.find((c) => cols.some((col) => col.toLowerCase() === c)) ??
-          cols.find((c) => candidates.some((cand) => c.toLowerCase().includes(cand))) ??
-          cols[0] ??
-          '';
-        writeStored(ENTITY_FIELD_KEY, entityNameField || null);
+        const inferred = inferEntityNameField(cols);
+        if (inferred) {
+          entityNameField = inferred;
+          entityNameOverridden = false;
+        } else {
+          const legacy = readStored(LEGACY_ENTITY_FIELD_KEY);
+          if (legacy && cols.includes(legacy)) {
+            entityNameField = legacy;
+            entityNameOverridden = true;
+            // Migrate the legacy global into the per-set key.
+            writeStored(setOverrideKey, legacy);
+          } else {
+            entityNameField = cols[0] ?? '';
+            entityNameOverridden = false;
+          }
+        }
       }
+      entityNamePickerOpen = false;
     } catch (err: unknown) {
       console.error('row.list', err);
     }
   }
 
-  // Persist the entity-name column whenever the user changes the dropdown.
-  $effect(() => {
-    if (entityNameField) writeStored(ENTITY_FIELD_KEY, entityNameField);
-  });
+  // When the user explicitly overrides the inferred entity-name column,
+  // persist it per-record-set (the key the loader reads on re-entry).
+  function commitEntityNameOverride(field: string) {
+    entityNameField = field;
+    entityNameOverridden = true;
+    entityNamePickerOpen = false;
+    if (selectedRecordSetId) {
+      writeStored(ENTITY_FIELD_KEY_PREFIX + selectedRecordSetId, field);
+    }
+  }
 
   // Roster operations — all persist the override under the active bundle's
   // key. They mutate the *current bundle's* roster only; switching bundles
@@ -359,20 +405,42 @@
     </section>
 
     {#if selectedSet}
-      <section class="card">
-        <h3>2 · Entity-name column</h3>
-        <p class="muted hint">
-          Which column holds the name to search for? (LinkedIn for X, Wikipedia for Y, etc.)
-        </p>
-        <select bind:value={entityNameField}>
-          {#each columns as col (col)}
-            <option value={col}>{col}</option>
-          {/each}
-        </select>
-      </section>
+      <!-- Inferred entity-name column (spec Decision §9). Read-only hint
+           with a change-link drop-down; no longer a full numbered step.
+           Pack Runner infers the column from a small candidate list;
+           override is persisted per record_set_id. -->
+      <div class="entity-hint" aria-live="polite">
+        {#if entityNameField}
+          <span class="muted">
+            Reading entity names from
+            <strong class="entity-col">{entityNameField}</strong>{#if entityNameOverridden} <span class="muted">(your override)</span>{/if}
+          </span>
+        {:else}
+          <span class="muted entity-warn">No entity-name column inferred — pick one:</span>
+        {/if}
+        {#if !entityNamePickerOpen}
+          <button
+            type="button"
+            class="entity-change"
+            onclick={() => (entityNamePickerOpen = true)}
+          >change ›</button>
+        {/if}
+        {#if entityNamePickerOpen || !entityNameField}
+          <select
+            class="entity-select"
+            value={entityNameField}
+            onchange={(e) => commitEntityNameOverride((e.currentTarget as HTMLSelectElement).value)}
+          >
+            <option value="" disabled>— pick a column —</option>
+            {#each columns as col (col)}
+              <option value={col}>{col}</option>
+            {/each}
+          </select>
+        {/if}
+      </div>
 
       <section class="card">
-        <h3>3 · Rows to fire against ({selectedRowCount}/{rowsForSelected.length})</h3>
+        <h3>2 · Rows to fire against ({selectedRowCount}/{rowsForSelected.length})</h3>
         <div class="row-filter-chips" role="tablist" aria-label="Filter rows by status">
           <button
             class="chip"
@@ -425,7 +493,7 @@
       </section>
 
       <section class="card">
-        <h3>4 · Bundle</h3>
+        <h3>3 · Bundle</h3>
         <p class="muted hint">
           A bundle is a named composition of packs with a default roster.
           Pick one to set what fires; tune the roster below if you need to.
@@ -448,7 +516,7 @@
       </section>
 
       <section class="card">
-        <h3>5 · Roster ({enabledPackCount}/{rosterSize})</h3>
+        <h3>4 · Roster ({enabledPackCount}/{rosterSize})</h3>
         <p class="muted hint">
           The bundle's packs — defaults are checked. Toggle to override; use
           <strong>solo</strong> next to a pack to fire just that one.
@@ -500,6 +568,17 @@
             Response Reviewer →
           </button>
         </div>
+        <!-- Target-column line (spec Decision §9): name what gets richer
+             when responses are accepted. Always visible when there are
+             rows in scope; reads "Augmenting `socials` on 67 rows" so the
+             user knows the property they're improving. -->
+        {#if cellsToFire > 0 || firing}
+          <p class="muted fire-sub fire-target">
+            Augmenting
+            {#each targetColumns as col, i (col)}<code class="target-col">{col}</code>{#if i < targetColumns.length - 1}, {/if}{/each}
+            on {selectedRowCount} {selectedRowCount === 1 ? 'row' : 'rows'}
+          </p>
+        {/if}
         {#if firing}
           <p class="muted fire-sub">
             Running server-side — results stream into Response Reviewer as each

--- a/apps/pack-runner/src/app.css
+++ b/apps/pack-runner/src/app.css
@@ -243,6 +243,51 @@
   margin-left: 0.2rem;
 }
 
+/* Entity-name hint affordance (spec Decision §9) — read-only line with
+   change-link. Replaces the prior Step 2 dropdown-as-primary-step. */
+.pr-app .entity-hint {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 0.25rem 0 0.75rem;
+  font-size: 0.8rem;
+}
+.pr-app .entity-col {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+.pr-app .entity-warn { color: var(--color-warn-text, var(--color-text)); }
+.pr-app .entity-change {
+  background: transparent;
+  border: 0;
+  color: var(--color-text-muted);
+  font: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+}
+.pr-app .entity-change:hover {
+  color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+}
+.pr-app .entity-select {
+  font-size: 0.8rem;
+  padding: 0.2rem 0.4rem;
+}
+
+/* Target-column line in the fire-card subhead (spec Decision §9) —
+   "Augmenting `socials` on N rows". Names what gets richer. */
+.pr-app .fire-target { margin-bottom: 0.15rem; }
+.pr-app .target-col {
+  color: var(--color-accent);
+  background: var(--color-field);
+  padding: 0.05rem 0.3rem;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+
 /* Pinned to the bottom of the scroll container so the run action stays
    reachable no matter how long the row/pack lists get. */
 .pr-app .fire-card {

--- a/apps/pack-runner/src/bundles.ts
+++ b/apps/pack-runner/src/bundles.ts
@@ -20,6 +20,9 @@ export type BundleConfig = {
   entity_type?: string;
   passes: 1 | 2;
   members: BundleMember[];
+  // What gets richer when responses are accepted. v1: every pack writes to
+  // row.socials → ['socials']. See spec Decision §9.
+  target_columns: string[];
 };
 
 export const PROFILE_BUILDER: BundleConfig = {
@@ -27,6 +30,7 @@ export const PROFILE_BUILDER: BundleConfig = {
   display_name: 'Profile Builder',
   description: 'Common-five social packs + Wikipedia — for any entity that lives on the public web',
   passes: 1,
+  target_columns: ['socials'],
   members: [
     { pack_id: 'linkedin-pack',  default: true,  pass: 1, required: false },
     { pack_id: 'x-pack',         default: true,  pass: 1, required: false },
@@ -44,6 +48,7 @@ export const PROFILE_BUILDER_NONPROFIT: BundleConfig = {
   description: 'Common-five + Wikipedia, biased for org-shaped entities; nonprofit-specific packs (Candid, ProPublica, IRS 990) opt-in once they ship',
   entity_type: 'nonprofit',
   passes: 1,
+  target_columns: ['socials'],
   members: [
     { pack_id: 'linkedin-pack',  default: true,  pass: 1, required: false },
     { pack_id: 'x-pack',         default: true,  pass: 1, required: false },
@@ -74,4 +79,31 @@ export const PACK_DISPLAY_NAMES: Record<string, string> = {
 
 export function packDisplayName(pack_id: string): string {
   return PACK_DISPLAY_NAMES[pack_id] ?? pack_id;
+}
+
+/**
+ * Ordered candidate list for auto-inferring which column holds the entity
+ * name. First match against the record set's schema wins. Spec Decision §9.
+ * The user can still override the choice via the small change-link in the
+ * Pack Runner head; the override is persisted per record_set_id.
+ */
+export const ENTITY_NAME_CANDIDATES: string[] = [
+  'Prospect / Organization',
+  'Organization',
+  'organization',
+  'Company',
+  'company',
+  'Name',
+  'name',
+  'entity_name',
+  'Entity Name',
+  'Full Name',
+];
+
+/** Pick the first candidate that exists in the supplied schema field names. */
+export function inferEntityNameField(fieldNames: string[]): string | null {
+  for (const candidate of ENTITY_NAME_CANDIDATES) {
+    if (fieldNames.includes(candidate)) return candidate;
+  }
+  return null;
 }

--- a/services/social-search/src/bundles.ts
+++ b/services/social-search/src/bundles.ts
@@ -28,6 +28,13 @@ export type BundleConfig = {
   entity_type?: string;        // matches the .common / .nonprofit suffix on chat verbs
   passes: 1 | 2;               // single-pass for v1
   members: BundleMember[];
+  // What gets richer when a fan-out succeeds and a human accepts the
+  // responses. v1: every pack writes into row.socials per the 2026-05-25
+  // design pivot, so every bundle targets ['socials']. Future bundles
+  // whose packs write to other columns can list multiple targets here;
+  // the Pack Runner UI surfaces the union near the Fire button so the
+  // user always knows what column(s) get improved (spec Decision §9).
+  target_columns: string[];
 };
 
 export const PROFILE_BUILDER: BundleConfig = {
@@ -35,6 +42,7 @@ export const PROFILE_BUILDER: BundleConfig = {
   display_name: 'Profile Builder',
   description: 'Common-five social packs + Wikipedia — for any entity that lives on the public web',
   passes: 1,
+  target_columns: ['socials'],
   members: [
     { pack_id: 'linkedin-pack',  default: true,  pass: 1, required: false },
     { pack_id: 'x-pack',         default: true,  pass: 1, required: false },
@@ -52,6 +60,7 @@ export const PROFILE_BUILDER_NONPROFIT: BundleConfig = {
   description: 'Common-five + Wikipedia, biased for org-shaped entities; nonprofit-specific packs (Candid, ProPublica, IRS 990) opt-in once they ship',
   entity_type: 'nonprofit',
   passes: 1,
+  target_columns: ['socials'],
   members: [
     { pack_id: 'linkedin-pack',  default: true,  pass: 1, required: false },
     { pack_id: 'x-pack',         default: true,  pass: 1, required: false },


### PR DESCRIPTION
## Summary

Implements spec **Decision §9** (added in #10). Pack Runner stops asking the user for input it can infer, and starts naming what it's actually improving.

## What's new on the screen

| Before | After |
|---|---|
| **Step 2 · Entity-name column** — a full numbered card with a dropdown asking the user to pick the column that holds the entity name | A compact one-line hint: *"Reading entity names from **Prospect / Organization** [change ›]"*. The picker only appears if the user clicks `change ›` or inference finds no match. |
| Fire button + cell-count subline (no mention of what gets richer) | Fire button + **"Augmenting `socials` on 67 rows"** target-column line + cell-count subline. The user always knows what column gets richer when they accept the responses. |
| Steps numbered 1·Record-set / 2·Entity-name / 3·Rows / 4·Bundle / 5·Roster | Steps renumbered 1·Record-set / 2·Rows / 3·Bundle / 4·Roster. The entity-name hint is lightweight (not a numbered card). |

## Under the hood

### `services/social-search/src/bundles.ts` + `apps/pack-runner/src/bundles.ts`

`BundleConfig` carries `target_columns: string[]`. v1 bundles both target `['socials']` per the 2026-05-25 design pivot (every pack writes to `row.socials`). Future bundles whose roster writes to other columns can list multiple targets; the Pack Runner UI renders the union.

### `apps/pack-runner/src/bundles.ts`

- `ENTITY_NAME_CANDIDATES` — the ordered candidate list (`Prospect / Organization`, `Organization`, `organization`, `Company`, `company`, `Name`, `name`, `entity_name`, `Entity Name`, `Full Name`).
- `inferEntityNameField(schemaFieldNames)` — pure helper; first-match-wins.

### `apps/pack-runner/src/App.svelte`

- On record-set load: auto-infer from the candidate list against the set's schema. If the user has a per-set override, the override wins. Migration fallback reads the legacy global `augment-it:pack-runner:entity-name-field` once.
- Per-set storage: `augment-it:entity-name-field:<record_set_id>`. Replaces the leaky global key.
- New derived `targetColumns` from `activeBundle.target_columns`.
- Step 2 dropdown replaced with an `.entity-hint` line + `change ›` button + lazy-mounted `<select>`.
- New `.fire-target` line in the fire-card subhead.

### `apps/pack-runner/src/app.css`

`.entity-hint`, `.entity-col`, `.entity-change`, `.entity-select`, `.fire-target`, `.target-col` — small additions, namespaced under `.pr-app`.

## Failure-shape mapping (from spec evidence #13)

- **Hidden** (what's improved is invisible) → fixed by the target-column line in the fire-card.
- **Foot-gun** (user is asked for input that should be inferred) → fixed by the candidate-list inference + demoted picker.

## Verification

- `pnpm build` clean in `apps/pack-runner/`.
- `pnpm typecheck` (tsc --noEmit) clean in `services/social-search/`.

## Test plan

- [ ] Load Pack Runner with a record set that has `Prospect / Organization` in its schema → hint reads "Reading entity names from **Prospect / Organization**" without user interaction.
- [ ] Load a set whose schema only has `Company` → hint reads "Reading entity names from **Company**".
- [ ] Load a set with no candidate match → hint reads "No entity-name column inferred — pick one:" and the dropdown is mounted.
- [ ] Click `change ›` → picker appears; pick a different column → hint updates, `(your override)` chip appears.
- [ ] Switch to another record set and back → override persists for the original set, the new set infers fresh.
- [ ] Fire button always shows **"Augmenting `socials` on N rows"** above the cell-count subline.
- [ ] Pre-§9 sessions: the legacy global `augment-it:pack-runner:entity-name-field` is honored on first load when no per-set override exists.

## Related

- Spec: `context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md` §9 (added in #10)
- Blueprint: `context-v/blueprints/Packs-and-Bundles-Pattern.md` §"Default to ready-to-fire" + §Row write-back
- Prior PRs: #6, #7, #8, #9, #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)