### PR TITLE
Bundle picker as dropdown — sibling-symmetric with Record Set select

### DIFF
--- a/apps/pack-runner/src/App.svelte
+++ b/apps/pack-runner/src/App.svelte
@@ -498,20 +498,18 @@
           A bundle is a named composition of packs with a default roster.
           Pick one to set what fires; tune the roster below if you need to.
         </p>
-        <div class="bundle-picker" role="tablist" aria-label="Bundle">
+        <select
+          class="bundle-select"
+          value={activeBundleId}
+          onchange={(e) => selectBundle((e.currentTarget as HTMLSelectElement).value)}
+          aria-label="Bundle"
+        >
           {#each BUNDLES as b (b.bundle_id)}
-            <button
-              class="bundle-chip"
-              class:active={b.bundle_id === activeBundleId}
-              role="tab"
-              aria-selected={b.bundle_id === activeBundleId}
-              title={b.description}
-              onclick={() => selectBundle(b.bundle_id)}
-            >
+            <option value={b.bundle_id} title={b.description}>
               {b.display_name}
-            </button>
+            </option>
           {/each}
-        </div>
+        </select>
         <p class="muted bundle-desc">{activeBundle.description}</p>
       </section>
 

--- a/apps/pack-runner/src/app.css
+++ b/apps/pack-runner/src/app.css
@@ -183,34 +183,12 @@
 .pr-app .pack-chip:hover { border-color: var(--color-accent); }
 .pr-app .pack-chip input { margin: 0; }
 
-/* Bundle picker (Phase 3) — segmented control above the roster panel.
-   Re-uses the chip aesthetic but with a stronger active state since the
-   bundle decides what fires. */
-.pr-app .bundle-picker {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  margin: 0.4rem 0 0.6rem;
-}
-.pr-app .bundle-chip {
-  background: transparent;
-  color: var(--color-text-muted);
-  border: 1px solid var(--color-border);
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  font-size: 0.8rem;
-  cursor: pointer;
-  letter-spacing: 0.02em;
-}
-.pr-app .bundle-chip:hover {
-  border-color: var(--color-accent);
-  color: var(--color-accent);
-}
-.pr-app .bundle-chip.active {
-  background: var(--color-accent);
-  color: var(--color-on-accent);
-  border-color: var(--color-accent);
-  cursor: default;
+/* Bundle picker — dropdown form (matches Step 1's Record Set select for
+   sibling-symmetry per the cross-cutting principles §2). The picker is
+   the primary "what fires" choice; the roster panel below tunes the
+   chosen bundle's members. */
+.pr-app .bundle-select {
+  margin-top: 0.4rem;
 }
 .pr-app .bundle-desc {
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary

Small UI change requested in person-on-the-screen feedback. The Step 3 (Bundle) picker was a pill-button segmented control; Step 1 (Record set) on the same surface is a `<select>` dropdown. Two "pick one of N" choices at the top of their respective steps should *look and behave the same way* — that's [principle §2: sibling controls get symmetric helpers](context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md#cross-cutting-principles), shipped one PR before this one.

## What changes

Bundle picker: pill buttons → `<select>` matching the Record-set select. Description line below remains. No behavioral change — `selectBundle()` still owns the localStorage persistence and per-bundle roster-override restoration.

## Files

- `apps/pack-runner/src/App.svelte` — markup swap.
- `apps/pack-runner/src/app.css` — drop `.bundle-picker` / `.bundle-chip` styles; replace with a small `.bundle-select` hook.

## Verification

`pnpm build` clean.

## Related

- Spec: `context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md` §Cross-cutting principles §2
- Prior PR: #12 (principles + audit harvest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)