### PR TITLE
spec: stub Tooltip-System + hanging-issue on principle §8 (v0.0.1.1)

### DIFF
--- a/context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md
+++ b/context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md
@@ -7,12 +7,13 @@ authors:
   - Michael Staton
 augmented_with:
   - Claude Code on Claude Opus 4.7
-semantic_version: 0.0.1.0
+semantic_version: 0.0.1.1
 revisions:
   - 2026-05-28 — Initial audit + 8 locked decisions (0.0.0.1).
   - 2026-06-01 — Shipped Phases 0–2d of [[../plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor]]. Marked Decisions §6 (peek labels), §7 (Deck → Flow), and §5 (composition) as shipped. The §5 open question "wrapper remote vs shared-state" resolved as **Option C — shell-level composite slot**; recorded in Decision §5 and removed from Open questions. Decision §1 (pack selection helpers on a flat list) **superseded** by Phase 3 bundle-first refactor — the plan's reconciliation against [[../blueprints/Packs-and-Bundles-Pattern]] showed that polishing a flat 7-pack list cements a model the blueprint says is wrong. Open question about Enrichment in the Flow strip resolved: **one bubble**, locked by the `ROTATION` shape shipped in Phase 2d. Per-surface audit updated with shipped status. Plan-level history lives in the plan; spec-level history is just the decisions changing.
   - 2026-06-01 — Phases 3, 4, 5 shipped (bundle-first Pack Runner, hierarchical Flow widget, Augment This Set). Added evidence #13 (Pack Runner doesn't show what it's improving + asks for input it could infer) and Decision §9 (surface the target column near the Fire button + auto-infer the entity-name column with a small change-link affordance). Seeded by the user re-walking the flow end-to-end after Phase 5 with fresh eyes.
   - 2026-06-01 — Phase 6 — **cross-cutting principles promoted from commented candidates to a stable list** (12 principles, partitioned by the three failure shapes + a dual-identity cross-class). Each principle is *earned* by named evidence + decisions — they're not abstract preferences. Per-surface audit closed out — every row now reads as ✅ shipped, deferred-with-link to a child spec, or `needs-audit` with a clear scope. Spec moves from 0.0.0.x to **0.0.1.0** because the principles section is a stable contract future affordances should consult. Closes the refactor's planning loop: the spec captures decisions, the plan captures sequencing + status, the principles capture the patterns earned.
+  - 2026-06-01 — Patch 0.0.1.1: flagged the **Tooltip System hanging issue** on principle §8 + added to Wish list. Native HTML `title=` is unreliable for the icon-with-tooltip pattern that's now load-bearing across the composite header, Flow widget, and Pack Runner's change-link affordance. Stubbed [[Tooltip-System]] so the work is discoverable when picked up. The principle stays — the plumbing needs replacing.
 tags:
   - Spec
   - Augment-It
@@ -507,6 +508,13 @@ failure shapes: **affordance discoverability** (counters *Hidden*),
    and §9 (Pack Runner's `change ›`). The shared component is
    `@augment-it/shared-ui/ToggleHeader__PromptOrPackage--Icons.svelte`;
    the pattern is the rule.*
+   **⚠ Hanging issue (2026-06-01):** the implementation today uses
+   the native HTML `title=` attribute, which has uncontrollable delay,
+   unstyled rendering, and patchy touch / screen-reader support. The
+   principle is right; the *plumbing* needs to become a first-class
+   Tooltip system before §8 reads reliably across every surface that
+   instances it. See [[Tooltip-System]] for scope, migration plan, and
+   open questions.
 9. **The toggle belongs to the slot, not the layout mode.** Mode
    switches that pretend to be intra-remote but are actually shell-
    level slot choices will break in some layout modes. Composite slots
@@ -550,6 +558,19 @@ Items the user explicitly flagged as "should be mentioned" but not necessarily
 inside this pass. Parked here so they're discoverable; each likely deserves
 its own context-v doc when picked up.
 
+- **Tooltip System — a first-class affordance, not the browser's half-working
+  `title=`.** Surfaced 2026-06-01 after Decision §9 shipped: native HTML
+  `title=` tooltips don't appear reliably (uncontrollable delay, unstyled,
+  patchy on touch / screen readers), which undercuts principle §8
+  ("icon-with-tooltip is the standard small-control affordance") on every
+  surface that instances it (composite header, Flow widget, Pack Runner's
+  `change ›`). The principle is right; the plumbing needs to become a
+  first-class shared component before §8 reads reliably. **Stubbed
+  2026-06-01:** [[Tooltip-System]] (spec). The audit's discipline of
+  "don't patch the instance — fix the pattern" applies here too: rather
+  than reach for a native tooltip workaround per call-site, build one
+  tooltip primitive in `packages/shared-ui` and migrate the four current
+  consumers in one pass.
 - **Per-remote in-app API documentation (CTA reveals docs *inside* the
   remote).** Each remote, the shell, and each service exposes its own
   documentation surface — not generic external API docs but **relevant**

--- a/context-v/specs/Tooltip-System.md
+++ b/context-v/specs/Tooltip-System.md
@@ -1,0 +1,131 @@
+---
+title: "Tooltip System — A First-Class Affordance, Not the Browser's Half-Working `title=`"
+lede: "augment-it's UX coherence audit promoted icon-with-tooltip to a shell-wide pattern (principle §8). The implementation today leans on the native HTML `title=` attribute, which doesn't show reliably across browsers, has uncontrollable delay, can't be styled, and carries no accessibility story beyond what the screen reader chooses to surface. For a load-bearing affordance pattern that's now the standard for binary picks, small-control switching, and 'change ›' affordances, this is an architecture gap. This spec scopes the Tooltip System as a first-class shell utility — a single component, a single discipline, a single accessibility story — and frames the migration plan."
+date_created: 2026-06-01
+date_modified: 2026-06-01
+authors:
+  - Michael Staton
+augmented_with:
+  - Claude Code on Claude Opus 4.7
+semantic_version: 0.0.0.1
+tags:
+  - Spec
+  - Augment-It
+  - Tooltip
+  - Shell
+  - Shared-UI
+  - Accessibility
+  - Affordance-Pattern
+  - Stub
+status: Draft
+---
+
+# Tooltip System
+
+<!-- Stub — captures the scope and the "why now" so the work is
+     discoverable when picked up. Body to be filled with the user. -->
+
+## Why this exists
+
+[[Shell-and-Micro-Frontend-UX-Coherence]] principle §8 says
+*"icon-with-tooltip is the standard small-control affordance"* — and
+across the refactor's six phases the pattern showed up in at least four
+places that are now load-bearing:
+
+- The enrichment composite header (`✎` / `⊞` toggle) — Phase 2c.
+- The Flow widget's Split / Full layout toggles (`⊟` / `▢`) — Phase 4.
+- The Flow widget's position-toggle chevron (`⇲` / `⇱`) — Phase 4.
+- Pack Runner's `change ›` affordance for the inferred entity-name
+  column — Decision §9.
+
+All of them rely on the native HTML `title=` attribute today. That
+attribute has well-known problems for a primary affordance pattern:
+
+1. **Delay is uncontrollable.** Browsers wait ~700ms-2s before showing,
+   so the user often gives up before the tooltip appears.
+2. **Styling is impossible.** Tokens like `--color-accent`, font
+   stacks, the muted-color story — none reach native tooltips.
+3. **Rich content is impossible.** No icons, no badges, no two-line
+   explanations with a hint + a shortcut.
+4. **Touch surfaces ignore them entirely.** A tooltip you can't see
+   on iPad / iPhone is functionally a missing affordance there.
+5. **Accessibility is patchy.** Screen readers handle `title=`
+   inconsistently — some announce the body, some don't, some treat it
+   as a label, some as a description.
+6. **Multiple tooltips on a tight pill row collide.** The Flow widget's
+   five bubbles + Split/Full + position-toggle is exactly the case
+   where native tooltips overlap and flicker.
+
+The audit promoted the pattern to a principle on the basis that *the
+affordance will read correctly when invoked*. Today the affordance only
+sometimes reads. That's the gap this spec is meant to close.
+
+## Scope (to lock with the user)
+
+Open. Candidate framing:
+
+- **A single shared component** at
+  `packages/shared-ui/src/Tooltip.svelte` (or co-located in a small
+  `Tooltip/` directory if we add multiple tip-shaped components). The
+  shell + every remote consumes the same component.
+- **Trigger model.** Most likely: a wrapper that takes a child slot
+  + a `content` string-or-Snippet + a placement preference. The
+  consumer writes `<Tooltip content="…">…the icon button…</Tooltip>`.
+  Alternative: an action directive (`use:tooltip={{ content }}`)
+  that's lighter at the call-site but less inspectable.
+- **Position engine.** Float around the trigger; auto-flip if the
+  preferred side overflows. Use a tiny dependency (e.g. floating-ui)
+  or roll a small `getBoundingClientRect`-based shim. Cost vs.
+  reach tradeoff.
+- **Delay + dismissal.** A single configurable delay (200ms feels
+  right; let's lock by trying). Hide on `mouseleave` AND on
+  `pointerdown` anywhere outside, AND on `Escape`.
+- **Accessibility.** Use `aria-describedby` linking the trigger to
+  the tooltip's id; set `role="tooltip"` on the panel. Tooltip
+  content is not interactive (no buttons inside; if you need a
+  button, use a Popover, not a Tooltip).
+- **Touch behaviour.** Long-press to show; tap-anywhere-else to
+  dismiss. Or: on touch surfaces, the tooltip body is always-visible
+  as inline secondary text. (Pick one; the icon-only-with-tooltip
+  pattern doesn't degrade well on touch.)
+
+## Migration plan (sketch)
+
+1. Ship the component + a `@augment-it/shared-ui/Tooltip.svelte`
+   export.
+2. Replace `title=` on the four load-bearing usages above. Order:
+   - Composite header (`ToggleHeader__PromptOrPackage--Icons.svelte`) — single highest-impact win.
+   - Flow widget (`shell/src/FlowWidget.svelte`) — the most-instances surface.
+   - Pack Runner's `change ›` — the most recent addition.
+3. Annotate principle §8 in
+   [[Shell-and-Micro-Frontend-UX-Coherence]] with a forward link
+   to this spec.
+4. Add a brief CHANGELOG entry naming the system shift (not just
+   the styling) since this is exactly the "make the pattern
+   actually reliable" moment.
+
+## Open questions
+
+- **Component vs. action directive?** Component is more obvious in
+  the source; directive is lighter at call-sites and survives
+  refactors of the wrapper element better.
+- **Position library?** floating-ui is heavy for the value here;
+  a 30-line shim might be sufficient.
+- **Touch-surface story.** Long-press vs. always-visible inline
+  secondary text — needs a UX call.
+- **Rich-content tooltips on bubbles.** Should the Flow widget's
+  bubble tooltips carry only the step label, or label + short
+  description + keyboard shortcut? The bubble strip is exactly the
+  case where richer tooltip content earns its keep.
+
+## Related
+
+- [[Shell-and-Micro-Frontend-UX-Coherence]] §Cross-cutting principles §8
+  — the principle this spec satisfies.
+- [[../plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor]] — the
+  six-phase refactor that promoted the pattern.
+- `packages/shared-ui/src/ToggleHeader__PromptOrPackage--Icons.svelte`
+  — the first consumer; will switch to `<Tooltip>` first when this
+  ships.
+- `shell/src/FlowWidget.svelte` — the highest-density consumer
+  (five bubble tooltips + two layout toggles + one position toggle).


### PR DESCRIPTION
## Summary

Spec-only. Surfaced by the user immediately after PR #13's bundle-picker dropdown shipped: tooltips aren't actually showing reliably. The right diagnosis isn't an inline patch — it's that **principle §8 (icon-with-tooltip)** is load-bearing across at least four surfaces now, and the implementation everywhere relies on native HTML `title=`, which is unreliable. The audit's own discipline says "fix the pattern, not the instance."

## Two changes

### `context-v/specs/Tooltip-System.md` (NEW, stub)

Frames the "why" (the gap is in the plumbing, not the principle):

- Native `title=` has uncontrollable delay, no styling, no rich content, patchy touch / screen-reader support, and overlap problems on dense surfaces like the Flow widget's five-bubble strip.
- The current consumers — composite header (✎/⊞), Flow widget (5 bubbles + ⊟/▢ + chevron), Pack Runner's `change ›` — are all icon-only without reliable tooltip plumbing. The affordance pattern only sometimes reads.

Candidate scope (to lock with you):

- Single shared component in `packages/shared-ui` vs. an action directive.
- Position engine — floating-ui vs. a 30-line `getBoundingClientRect` shim.
- Delay + dismissal discipline (default 200ms?).
- Accessibility: `aria-describedby` + `role="tooltip"`.
- Touch behaviour: long-press vs. always-visible inline secondary text. Pick one.

Migration order locked in the stub: composite header first (single highest-impact win), Flow widget next (most-instances surface), Pack Runner's `change ›` last.

### Parent spec annotation + Wish list

- Principle §8 gains a `⚠ Hanging issue` block pointing to `Tooltip-System`.
- Wish list gains a Tooltip-System entry naming the discipline ("don't patch the instance, fix the pattern").
- Spec metadata: `0.0.1.0 → 0.0.1.1`; revisions block records the addition.

## Why a stub rather than an implementation now

The reliability issue spans every surface that instances §8. Fixing it per call-site multiplies the inconsistency we just designed out. One Tooltip primitive in shared-ui, migrated in one pass, keeps the pattern coherent — and lets the user lock the open questions (touch behaviour, position library) before we write code.

## Related

- Spec: `context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md` §Cross-cutting principles §8 + §Wish list
- New stub: `context-v/specs/Tooltip-System.md`
- Prior PRs: #6, #7, #8, #9, #10, #11, #12, #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)