### PR TITLE
spec: sharpen Tooltip-System — family + geometry + Tooltip-Walkthrough

### DIFF
--- a/context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md
+++ b/context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md
@@ -7,13 +7,14 @@ authors:
   - Michael Staton
 augmented_with:
   - Claude Code on Claude Opus 4.7
-semantic_version: 0.0.1.1
+semantic_version: 0.0.1.2
 revisions:
   - 2026-05-28 — Initial audit + 8 locked decisions (0.0.0.1).
   - 2026-06-01 — Shipped Phases 0–2d of [[../plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor]]. Marked Decisions §6 (peek labels), §7 (Deck → Flow), and §5 (composition) as shipped. The §5 open question "wrapper remote vs shared-state" resolved as **Option C — shell-level composite slot**; recorded in Decision §5 and removed from Open questions. Decision §1 (pack selection helpers on a flat list) **superseded** by Phase 3 bundle-first refactor — the plan's reconciliation against [[../blueprints/Packs-and-Bundles-Pattern]] showed that polishing a flat 7-pack list cements a model the blueprint says is wrong. Open question about Enrichment in the Flow strip resolved: **one bubble**, locked by the `ROTATION` shape shipped in Phase 2d. Per-surface audit updated with shipped status. Plan-level history lives in the plan; spec-level history is just the decisions changing.
   - 2026-06-01 — Phases 3, 4, 5 shipped (bundle-first Pack Runner, hierarchical Flow widget, Augment This Set). Added evidence #13 (Pack Runner doesn't show what it's improving + asks for input it could infer) and Decision §9 (surface the target column near the Fire button + auto-infer the entity-name column with a small change-link affordance). Seeded by the user re-walking the flow end-to-end after Phase 5 with fresh eyes.
   - 2026-06-01 — Phase 6 — **cross-cutting principles promoted from commented candidates to a stable list** (12 principles, partitioned by the three failure shapes + a dual-identity cross-class). Each principle is *earned* by named evidence + decisions — they're not abstract preferences. Per-surface audit closed out — every row now reads as ✅ shipped, deferred-with-link to a child spec, or `needs-audit` with a clear scope. Spec moves from 0.0.0.x to **0.0.1.0** because the principles section is a stable contract future affordances should consult. Closes the refactor's planning loop: the spec captures decisions, the plan captures sequencing + status, the principles capture the patterns earned.
   - 2026-06-01 — Patch 0.0.1.1: flagged the **Tooltip System hanging issue** on principle §8 + added to Wish list. Native HTML `title=` is unreliable for the icon-with-tooltip pattern that's now load-bearing across the composite header, Flow widget, and Pack Runner's change-link affordance. Stubbed [[Tooltip-System]] so the work is discoverable when picked up. The principle stays — the plumbing needs replacing.
+  - 2026-06-01 — Patch 0.0.1.2: **sharpened the Tooltip System scope** after the user named the real shape. Not one component — a family (`Tooltip--Simple`, `Tooltip--Rich`, `Tooltip--Popover`) with shared geometry (`from` directionality with arrow connector, `distance` in rem) and a higher-level **Tooltip-Walkthrough** surface for first-run onboarding and returning-user re-orientation. Locked the framing: *apps succeed at onboarding/orientation, not at functionality.* Updated Wish list entry + §8 annotation to point at the sharpened scope; [[Tooltip-System]] itself moves from stub to scoped (v0.0.0.2).
 tags:
   - Spec
   - Augment-It
@@ -512,9 +513,14 @@ failure shapes: **affordance discoverability** (counters *Hidden*),
    the native HTML `title=` attribute, which has uncontrollable delay,
    unstyled rendering, and patchy touch / screen-reader support. The
    principle is right; the *plumbing* needs to become a first-class
-   Tooltip system before §8 reads reliably across every surface that
-   instances it. See [[Tooltip-System]] for scope, migration plan, and
-   open questions.
+   Tooltip *system* — a family of primitives (`Tooltip--Simple`,
+   `Tooltip--Rich`, `Tooltip--Popover`) with shared geometry (`from`
+   directionality + arrow connector, `distance` in rem, dismissal
+   discipline), plus a higher-level **Tooltip-Walkthrough** surface
+   for first-run onboarding and returning-user re-orientation tours.
+   See [[Tooltip-System]] (sharpened 2026-06-01) for scope, the
+   family, the geometry props, the walkthrough mechanics, and the
+   migration plan.
 9. **The toggle belongs to the slot, not the layout mode.** Mode
    switches that pretend to be intra-remote but are actually shell-
    level slot choices will break in some layout modes. Composite slots
@@ -558,19 +564,21 @@ Items the user explicitly flagged as "should be mentioned" but not necessarily
 inside this pass. Parked here so they're discoverable; each likely deserves
 its own context-v doc when picked up.
 
-- **Tooltip System — a first-class affordance, not the browser's half-working
-  `title=`.** Surfaced 2026-06-01 after Decision §9 shipped: native HTML
-  `title=` tooltips don't appear reliably (uncontrollable delay, unstyled,
-  patchy on touch / screen readers), which undercuts principle §8
-  ("icon-with-tooltip is the standard small-control affordance") on every
-  surface that instances it (composite header, Flow widget, Pack Runner's
-  `change ›`). The principle is right; the plumbing needs to become a
-  first-class shared component before §8 reads reliably. **Stubbed
-  2026-06-01:** [[Tooltip-System]] (spec). The audit's discipline of
-  "don't patch the instance — fix the pattern" applies here too: rather
-  than reach for a native tooltip workaround per call-site, build one
-  tooltip primitive in `packages/shared-ui` and migrate the four current
-  consumers in one pass.
+- **Tooltip System — a versatile first-class family, plus a Walkthrough
+  for new and returning users.** Surfaced 2026-06-01 after Decision §9
+  shipped; sharpened later the same day. The first cut framed the gap
+  as "native `title=` is unreliable; build one Tooltip component." The
+  sharpened framing is bigger: it's a **family of primitives**
+  (`Tooltip--Simple`, `Tooltip--Rich`, `Tooltip--Popover`) with shared
+  geometry (`from` directionality with arrow connector, `distance` in
+  rem, dismissal + accessibility discipline) AND a higher-level
+  **Tooltip-Walkthrough** surface that uses the family to deliver
+  first-run onboarding and returning-user re-orientation tours since a
+  declared milestone. The locked framing: *most apps don't succeed or
+  fail at functionality; they succeed or fail at onboarding,
+  orientation, and re-orientation.* Tooltips and the walkthrough that
+  uses them are how augment-it earns those moments. **Stubbed and
+  sharpened 2026-06-01:** [[Tooltip-System]] (spec, v0.0.0.2).
 - **Per-remote in-app API documentation (CTA reveals docs *inside* the
   remote).** Each remote, the shell, and each service exposes its own
   documentation surface — not generic external API docs but **relevant**

--- a/context-v/specs/Tooltip-System.md
+++ b/context-v/specs/Tooltip-System.md
@@ -1,13 +1,16 @@
 ---
-title: "Tooltip System — A First-Class Affordance, Not the Browser's Half-Working `title=`"
-lede: "augment-it's UX coherence audit promoted icon-with-tooltip to a shell-wide pattern (principle §8). The implementation today leans on the native HTML `title=` attribute, which doesn't show reliably across browsers, has uncontrollable delay, can't be styled, and carries no accessibility story beyond what the screen reader chooses to surface. For a load-bearing affordance pattern that's now the standard for binary picks, small-control switching, and 'change ›' affordances, this is an architecture gap. This spec scopes the Tooltip System as a first-class shell utility — a single component, a single discipline, a single accessibility story — and frames the migration plan."
+title: "Tooltip System — A Versatile First-Class Family, Plus a Walkthrough for New and Returning Users"
+lede: "Most apps don't succeed or fail at functionality. They succeed or fail at onboarding, orientation, and re-orientation when a returning user comes back to find things have moved. Tooltips are the load-bearing affordance for all three — and they have to be a versatile first-class family, not a single component bolted onto the browser's half-working `title=`. This spec scopes a family of tooltip primitives (Simple, Rich, Popover), the geometry they share (directional `from` placement with arrow connector, configurable distance, dismissal discipline, accessibility), and the **Tooltip-Walkthrough** surface that sits on top — a guided series of tooltips that fire for users who haven't logged in since a given milestone, so they discover what changed without reading release notes."
 date_created: 2026-06-01
 date_modified: 2026-06-01
 authors:
   - Michael Staton
 augmented_with:
   - Claude Code on Claude Opus 4.7
-semantic_version: 0.0.0.1
+semantic_version: 0.0.0.2
+revisions:
+  - 2026-06-01 — Initial stub (0.0.0.1). Framed the gap (native `title=` is unreliable) and the migration order.
+  - 2026-06-01 — Sharpened by the user (0.0.0.2). Added: the **subcomponent family** (Tooltip--Simple, Tooltip--Rich, Tooltip--Popover) rather than one component; the **`from` directionality prop** with cardinal + diagonal placements and an arrow/triangle connector; the **`distance` rem prop** with a small default; and the **Tooltip-Walkthrough** surface for new- and returning-user orientation. Framing locked: apps succeed at onboarding/orientation, not at functionality.
 tags:
   - Spec
   - Augment-It
@@ -16,116 +19,289 @@ tags:
   - Shared-UI
   - Accessibility
   - Affordance-Pattern
-  - Stub
+  - Onboarding
+  - Walkthrough
+  - First-Class
 status: Draft
 ---
 
 # Tooltip System
 
-<!-- Stub — captures the scope and the "why now" so the work is
-     discoverable when picked up. Body to be filled with the user. -->
-
 ## Why this exists
 
 [[Shell-and-Micro-Frontend-UX-Coherence]] principle §8 says
-*"icon-with-tooltip is the standard small-control affordance"* — and
-across the refactor's six phases the pattern showed up in at least four
-places that are now load-bearing:
+*"icon-with-tooltip is the standard small-control affordance"*, and
+across the refactor's six phases the pattern lands in at least four
+places that are now load-bearing: the enrichment composite header, the
+Flow widget (five bubbles + Split/Full + position-toggle), and Pack
+Runner's `change ›`. The audit promoted the pattern to a principle on
+the bet that *the affordance will read correctly when invoked*. Today
+the affordance only sometimes reads, because every consumer uses the
+native HTML `title=` attribute — uncontrollable delay, no styling, no
+rich content, patchy touch / screen-reader support, overlap problems on
+dense surfaces, and zero ability to sequence them for onboarding.
 
-- The enrichment composite header (`✎` / `⊞` toggle) — Phase 2c.
-- The Flow widget's Split / Full layout toggles (`⊟` / `▢`) — Phase 4.
-- The Flow widget's position-toggle chevron (`⇲` / `⇱`) — Phase 4.
-- Pack Runner's `change ›` affordance for the inferred entity-name
-  column — Decision §9.
+The framing this spec proceeds from:
 
-All of them rely on the native HTML `title=` attribute today. That
-attribute has well-known problems for a primary affordance pattern:
+> Most apps don't succeed or fail at functionality. They succeed or
+> fail at **onboarding, orientation, and re-orientation when a
+> returning user comes back to find things have moved**.
 
-1. **Delay is uncontrollable.** Browsers wait ~700ms-2s before showing,
-   so the user often gives up before the tooltip appears.
-2. **Styling is impossible.** Tokens like `--color-accent`, font
-   stacks, the muted-color story — none reach native tooltips.
-3. **Rich content is impossible.** No icons, no badges, no two-line
-   explanations with a hint + a shortcut.
-4. **Touch surfaces ignore them entirely.** A tooltip you can't see
-   on iPad / iPhone is functionally a missing affordance there.
-5. **Accessibility is patchy.** Screen readers handle `title=`
-   inconsistently — some announce the body, some don't, some treat it
-   as a label, some as a description.
-6. **Multiple tooltips on a tight pill row collide.** The Flow widget's
-   five bubbles + Split/Full + position-toggle is exactly the case
-   where native tooltips overlap and flicker.
+Better if the app is so simple it doesn't even need orientation —
+but even then, there is usually still a "new user" and a "returning
+user" experience, and the closer the app gets to "doing complex things
+simply," the more those moments earn their keep. Tooltips are the
+load-bearing affordance for all three.
 
-The audit promoted the pattern to a principle on the basis that *the
-affordance will read correctly when invoked*. Today the affordance only
-sometimes reads. That's the gap this spec is meant to close.
+So the gap isn't "the tooltip implementation is unreliable." The gap is
+**we don't have a Tooltip *system***. A system has a family of
+primitives at the leaf, shared geometry across them, and a higher-level
+surface (the Walkthrough) that composes them. This spec scopes all
+three.
 
-## Scope (to lock with the user)
+## The subcomponent family
 
-Open. Candidate framing:
+One component is the wrong abstraction — the cases differ in *content
+shape*, and forcing one component to handle them all either bloats the
+API or pushes complexity to every call-site. The right shape is a tiny
+family of components in `packages/shared-ui/`. Following the BEM-ish
+file convention already established by
+`ToggleHeader__PromptOrPackage--Icons.svelte`:
 
-- **A single shared component** at
-  `packages/shared-ui/src/Tooltip.svelte` (or co-located in a small
-  `Tooltip/` directory if we add multiple tip-shaped components). The
-  shell + every remote consumes the same component.
-- **Trigger model.** Most likely: a wrapper that takes a child slot
-  + a `content` string-or-Snippet + a placement preference. The
-  consumer writes `<Tooltip content="…">…the icon button…</Tooltip>`.
-  Alternative: an action directive (`use:tooltip={{ content }}`)
-  that's lighter at the call-site but less inspectable.
-- **Position engine.** Float around the trigger; auto-flip if the
-  preferred side overflows. Use a tiny dependency (e.g. floating-ui)
-  or roll a small `getBoundingClientRect`-based shim. Cost vs.
-  reach tradeoff.
-- **Delay + dismissal.** A single configurable delay (200ms feels
-  right; let's lock by trying). Hide on `mouseleave` AND on
-  `pointerdown` anywhere outside, AND on `Escape`.
-- **Accessibility.** Use `aria-describedby` linking the trigger to
-  the tooltip's id; set `role="tooltip"` on the panel. Tooltip
-  content is not interactive (no buttons inside; if you need a
-  button, use a Popover, not a Tooltip).
-- **Touch behaviour.** Long-press to show; tap-anywhere-else to
-  dismiss. Or: on touch surfaces, the tooltip body is always-visible
-  as inline secondary text. (Pick one; the icon-only-with-tooltip
-  pattern doesn't degrade well on touch.)
+### `Tooltip--Simple.svelte` — the 90% case
 
-## Migration plan (sketch)
+A one-line tooltip. Plain text, no icon, no actions. This is what every
+current `title=` becomes when the migration runs. The composite header's
+✎/⊞ icons, the Flow widget's bubble strip, Pack Runner's `change ›` —
+all of them. **Default; reach for this first.**
 
-1. Ship the component + a `@augment-it/shared-ui/Tooltip.svelte`
-   export.
-2. Replace `title=` on the four load-bearing usages above. Order:
-   - Composite header (`ToggleHeader__PromptOrPackage--Icons.svelte`) — single highest-impact win.
-   - Flow widget (`shell/src/FlowWidget.svelte`) — the most-instances surface.
-   - Pack Runner's `change ›` — the most recent addition.
-3. Annotate principle §8 in
-   [[Shell-and-Micro-Frontend-UX-Coherence]] with a forward link
-   to this spec.
-4. Add a brief CHANGELOG entry naming the system shift (not just
-   the styling) since this is exactly the "make the pattern
-   actually reliable" moment.
+```svelte
+<Tooltip--Simple content="Custom prompt — author a free-text LLM prompt">
+  <button aria-label="Custom prompt">✎</button>
+</Tooltip--Simple>
+```
+
+### `Tooltip--Rich.svelte` — when one line isn't enough
+
+Multi-line. Optional leading icon, an `<strong>`-able title line, a
+secondary muted line, an optional keyboard-shortcut chip. Still
+*non-interactive* — same a11y rules as Simple. Good for the Flow
+widget's bubbles when the tooltip should show step name + short
+description + "step 3 of 5" position, or for Pack Runner's bundle
+description when hovering the Bundle select.
+
+```svelte
+<Tooltip--Rich
+  title="Profile Builder · Nonprofit"
+  body="Common-five + Wikipedia, biased for org-shaped entities"
+  shortcut="3"
+  from="bottom"
+>
+  <li class="bubble">3</li>
+</Tooltip--Rich>
+```
+
+### `Tooltip--Popover.svelte` — the boundary case
+
+When the floating panel needs to **carry interactive content**, it's
+no longer a tooltip; it's a Popover. Same geometry primitives (`from`,
+`distance`, arrow), different a11y story (`role="dialog"`, focus
+management, ESC + outside-click dismissal, keyboard trap if modal). The
+Walkthrough below is the first consumer.
+
+```svelte
+<Tooltip--Popover from="top-left" distance={1.25}>
+  <h4>This panel moved</h4>
+  <p>The Flow widget is now hierarchical — bubbles for steps, icons for layout.</p>
+  <div class="actions">
+    <button onclick={next}>Got it</button>
+    <button onclick={skip}>Skip the tour</button>
+  </div>
+</Tooltip--Popover>
+```
+
+Naming alternative considered: `--Simple` / `--Base` / `--Complex`.
+Rejected — *Simple/Rich/Popover* names the **content shape** at each
+level; *Simple/Base/Complex* names a vague complexity axis that doesn't
+tell the consumer when to reach for which. Pick the one the API
+documents itself with.
+
+## Shared geometry — what every tooltip in the family agrees on
+
+### `from`: directionality from the trigger
+
+Where the tooltip is positioned relative to the trigger element, and
+where the arrow attaches. Cardinal directions are the floor; diagonals
+let the arrow point at a corner of the trigger.
+
+| `from` value | Tooltip renders on the trigger's | Arrow attaches at |
+|---|---|---|
+| `top` | top | bottom-center of tooltip → top of trigger |
+| `bottom` | bottom | top-center → bottom of trigger |
+| `left` | left | right-center → left of trigger |
+| `right` | right | left-center → right of trigger |
+| `top-left` | bottom-right *(opposite corner)* | bottom-right corner → top-left of trigger |
+| `top-right` | bottom-left | bottom-left corner → top-right of trigger |
+| `bottom-left` | top-right | top-right corner → bottom-left of trigger |
+| `bottom-right` | top-left | top-left corner → bottom-right of trigger |
+
+The semantic: **`from` names the side / corner of the trigger the arrow
+attaches to.** A `from="top-left"` arrow attaches at the trigger's
+top-left corner, so the tooltip body sits opposite — at the
+bottom-right relative to the trigger. This matches how designers and
+support agents think ("the arrow points up-and-left") and removes the
+"is this the side of the trigger or the side of the tooltip?" guessing
+game.
+
+**Auto-flip on overflow.** If the preferred `from` would push the
+tooltip off the viewport, the position engine flips to the opposite
+side, *without* rotating the consumer's mental model. The arrow follows.
+
+### `distance`: rem gap between trigger and tooltip
+
+Number, default `0.4` rem (just barely off the trigger — the standard
+icon-tooltip). Pass higher values when the tooltip needs visual
+breathing room (e.g. on a dense bubble strip) or when the trigger has
+its own visible padding that would otherwise visually collide with the
+arrow.
+
+```svelte
+<Tooltip--Simple content="Move Flow widget to left rail" distance={0.6}>
+  <button class="chevron">⇲</button>
+</Tooltip--Simple>
+```
+
+### Delay, dismissal, accessibility
+
+Locked across the family:
+
+- **Show delay** — `200ms` default; configurable via `delay` prop. Walkthrough overrides to `0` because the user explicitly invoked the sequence.
+- **Hide** — on `mouseleave` AND `pointerdown` outside AND `Escape`.
+  Tooltips and Popovers both honor `Escape`; Popover additionally
+  traps focus while open.
+- **A11y for Simple + Rich** — `aria-describedby` on the trigger, `role="tooltip"` on the panel, content not focusable, no interactive children.
+- **A11y for Popover** — `role="dialog"`, `aria-modal="true"` when modal, focus moves into the panel on open and returns to the trigger on close. Interactive children allowed.
+- **Touch** — long-press (~500ms) to show; tap-outside dismisses. Or
+  — the open question — on touch surfaces, the tooltip body renders as
+  always-visible inline secondary text under the icon. Pick one default
+  with a per-call escape hatch.
+
+## The Tooltip-Walkthrough surface
+
+The bigger move. A **walkthrough** is a guided, ordered sequence of
+tooltips (mostly `Tooltip--Popover` so each step can carry a Next /
+Skip / Got-it action) that fires for a user under specific conditions:
+
+- **First-run** — the user just signed in for the first time. Tour
+  the shell: Flow widget → composite header → Pack Runner → Response
+  Reviewer → Enhanced Records.
+- **Returning-since-milestone** — the user last signed in before a
+  declared milestone (e.g. `2026-06-01: Flow widget + Augment This
+  Set + bundles`). On their next sign-in, the relevant subset of
+  steps fires so they discover what moved without reading release
+  notes.
+- **Per-surface re-orientation** — the user opens a surface they
+  haven't used in N weeks. A shorter, single-surface tour fires.
+
+This is a recognized pattern. driver.js, Shepherd.js, react-joyride,
+intro.js, and Notion's first-run series are all instances. The reason
+to build our own rather than vendor: it has to compose with the
+composite slot, the Flow widget, the cross-remote navigate event, and
+the dual-identity framing (a demo visitor and an outside user want
+different first-run shapes — the system has to render both).
+
+### Walkthrough shape (to lock with the user)
+
+- **Milestone registry.** A small TS module declares milestones with
+  ISO dates and the bundle of steps each milestone introduces.
+  `context-v/blueprints/Walkthroughs/milestones.ts` is a candidate
+  location.
+- **Cohort logic.** On sign-in, compute `unseenMilestones = milestones
+  filter (lastSignIn < milestone.date AND !user.dismissed(milestone))`.
+  Run the steps for each unseen milestone in date order.
+- **Step shape.** Each step targets a CSS selector (or a known
+  remote/slot/composite id), specifies a `from` direction and
+  `distance`, supplies title + body + optional CTA actions
+  (`primary: 'Next' | 'Got it'`, `secondary: 'Skip the tour' | null`).
+- **Persistence.** `localStorage['augment-it:walkthrough:dismissed']`
+  is a set of milestone ids the user has dismissed. Plus a per-step
+  `:seen` set for "show me only the steps I haven't seen yet."
+- **Composability with the shell.** A step can drive
+  `augment-it:navigate` to bring its target surface into focus before
+  the popover appears — so the tour can walk Record Collector →
+  Enrichment → Response Reviewer without the user manually navigating.
+- **Dual-identity branching.** A step can declare an `audience`
+  (`'user' | 'visitor'`) and the walkthrough engine picks the shape
+  appropriate for the active mode. Honors principle §12.
+
+### Why this earns its keep
+
+The framing again: **apps succeed at onboarding, orientation, and
+re-orientation, not at functionality.** augment-it is currently shaped
+for the user who already understands the augment-it model. A first-run
+visitor lands on the shell and sees five rotation steps, a composite
+slot with a ✎/⊞ toggle, a chat rail, and a Flow widget — all of which
+are coherent *once you know the model*, none of which announce
+themselves. The walkthrough is the announcement.
+
+The returning-user case is the more under-served one. *"You came back
+after we shipped Augment This Set, the Flow widget, and bundle-first
+Pack Runner. Here's a 90-second tour of what moved."* That moment is
+where users either feel met-where-they-are or feel like the app got
+rebuilt without telling them.
+
+## Migration plan
+
+In order:
+
+1. **Ship `Tooltip--Simple`.** Single component, single migration: replace
+   `title=` on the four current consumers — composite header, Flow
+   widget (bubbles + Split/Full + chevron), Pack Runner's `change ›`,
+   and any other surface that's accumulated `title=` since. One PR.
+2. **Add `Tooltip--Rich`.** No call-site change yet; just the API. Land
+   when a surface (likely the Flow widget bubbles for richer content)
+   wants more than a line.
+3. **Add `Tooltip--Popover`.** The Walkthrough's prerequisite.
+4. **Ship Tooltip-Walkthrough**, milestone registry + cohort logic +
+   the first three milestones (everything Phase 1-5 shipped). Lands as
+   a separate child spec when picked up.
 
 ## Open questions
 
-- **Component vs. action directive?** Component is more obvious in
-  the source; directive is lighter at call-sites and survives
-  refactors of the wrapper element better.
-- **Position library?** floating-ui is heavy for the value here;
-  a 30-line shim might be sufficient.
-- **Touch-surface story.** Long-press vs. always-visible inline
-  secondary text — needs a UX call.
-- **Rich-content tooltips on bubbles.** Should the Flow widget's
-  bubble tooltips carry only the step label, or label + short
-  description + keyboard shortcut? The bubble strip is exactly the
-  case where richer tooltip content earns its keep.
+- **Component vs. action directive.** A component (`<Tooltip--Simple>`)
+  is more obvious in source and easier to nest. An action directive
+  (`use:tooltip={{ content, from }}`) is lighter at call-sites. The
+  current lean is component-shaped because the family has multiple
+  variants — directives don't compose well with a `Tooltip--Rich`
+  body slot.
+- **Position engine.** `floating-ui` (~10kB gz) handles all eight
+  placements + auto-flip + arrow positioning correctly across edge
+  cases. A hand-rolled 30-line `getBoundingClientRect` shim works for
+  the cardinal four; diagonals + arrow geometry get gnarly quickly.
+  Lean: pull `floating-ui` for the cost predictability.
+- **Touch default.** Long-press-to-show vs. always-visible-secondary-text.
+  iPad / tablet usage of augment-it is currently low; this can be
+  shipped as long-press with an escape hatch and revisited.
+- **Where does the milestone registry live?** Per-app or shared in
+  shared-ui. Likely shared — milestones are about the *product* shape,
+  not any one remote.
+- **Walkthrough authoring UX.** Inline as plain TS in the registry, or
+  a tiny in-app authoring surface? Inline TS for v1; revisit if step
+  count grows past ~30.
 
 ## Related
 
-- [[Shell-and-Micro-Frontend-UX-Coherence]] §Cross-cutting principles §8
-  — the principle this spec satisfies.
-- [[../plans/Shell-and-Micro-Frontend-UX-Coherence-Refactor]] — the
-  six-phase refactor that promoted the pattern.
-- `packages/shared-ui/src/ToggleHeader__PromptOrPackage--Icons.svelte`
-  — the first consumer; will switch to `<Tooltip>` first when this
-  ships.
-- `shell/src/FlowWidget.svelte` — the highest-density consumer
+- [[Shell-and-Micro-Frontend-UX-Coherence]] §Cross-cutting principles §8 —
+  the principle this system satisfies. The `⚠ Hanging issue` annotation
+  on §8 points here.
+- [[Initial-User-Experience]] — landing-through-onboarding spec; the
+  Walkthrough is the first-run mechanic that spec needs.
+- [[../blueprints/Augment-It-as-Working-App-and-Architecture-Demo]] —
+  the dual-identity blueprint; the walkthrough's `audience` branching
+  is how that framing reaches the user.
+- `packages/shared-ui/src/ToggleHeader__PromptOrPackage--Icons.svelte` —
+  the first migration target (its three `title=` attributes).
+- `shell/src/FlowWidget.svelte` — the highest-density migration target
   (five bubble tooltips + two layout toggles + one position toggle).
+- `apps/pack-runner/src/App.svelte` — the most recent `title=` addition
+  (the `change ›` affordance for the inferred entity-name column).


### PR DESCRIPTION
## Summary

Spec-only. Sharpens the [Tooltip-System stub](context-v/specs/Tooltip-System.md) shipped in PR #14 after the user named the real shape: tooltips aren't one component — they're a family, and the bigger move is the **Tooltip-Walkthrough** surface that uses them for onboarding and re-orientation.

The locked framing:

> Most apps don't succeed or fail at functionality. They succeed or fail at **onboarding, orientation, and re-orientation**.

## The family

| Component | When to reach for it |
|---|---|
| `Tooltip--Simple` | One-line plain text. **The 90% case.** What every current `title=` becomes. |
| `Tooltip--Rich` | Multi-line; optional icon + title + body + shortcut chip. Still non-interactive (same a11y as Simple). Flow widget bubbles want this. |
| `Tooltip--Popover` | Interactive content (buttons, links). The Walkthrough's prerequisite. `role="dialog"` + focus management. |

Naming alternative considered (`--Simple`/`--Base`/`--Complex`) — rejected because the chosen names describe **content shape** at each level; the alternative describes a vague complexity axis that doesn't tell the consumer when to reach for which.

## Shared geometry

### `from` directionality prop

Names the **side or corner of the trigger** the arrow attaches to. Cardinal + four diagonals:

| `from` | Tooltip renders at | Arrow attaches |
|---|---|---|
| `top` | trigger top, body above | bottom-center → top of trigger |
| `top-left` | bottom-right (opposite corner) | bottom-right corner → top-left of trigger |
| `bottom-right` | top-left (opposite corner) | top-left corner → bottom-right of trigger |
| `left` / `right` / `bottom` / `bottom-left` / `top-right` | symmetric | symmetric |

This mirrors how designers think (*"the arrow points up-and-left"*) and removes the "is this the side of the trigger or the side of the tooltip?" guessing game. Auto-flip on viewport overflow without rotating the consumer's mental model.

### `distance` rem prop

Number, default `0.4` rem. Override per-call for breathing room on dense surfaces (Flow widget bubble strip) or to clear trigger padding.

### Locked across the family

- Show delay: `200ms` default. Walkthrough overrides to `0`.
- Hide on: `mouseleave` AND outside `pointerdown` AND `Escape`.
- A11y: `Tooltip--Simple` + `Tooltip--Rich` use `role="tooltip"` + `aria-describedby` + no interactive children. `Tooltip--Popover` uses `role="dialog"` + focus trap + return-focus-on-close.

## The Tooltip-Walkthrough surface

The bigger move. Guided ordered sequence of `Tooltip--Popover` steps. Three triggers:

- **First-run** — user just signed in for the first time. Tour the shell.
- **Returning-since-milestone** — user last signed in before a declared milestone. The relevant subset of steps fires so they discover what moved without reading release notes. **The under-served case.**
- **Per-surface re-orientation** — user opens a surface they haven't used in N weeks.

A step targets a CSS selector or a known remote/composite id, specifies `from` + `distance`, supplies title + body + CTA actions. The walkthrough engine can drive `augment-it:navigate` to bring the target into focus *before* the popover appears, so the tour can walk Record Collector → Enrichment → Response Reviewer without manual navigation.

`audience: 'user' | 'visitor'` branching honors the dual-identity principle (§12).

**Why build rather than vendor** (Shepherd.js / driver.js / react-joyride / intro.js all do versions of this): it has to compose with the composite slot, Flow widget, `augment-it:navigate`, and the dual-identity framing.

## Migration plan

1. Ship `Tooltip--Simple` + replace the four current `title=` call-sites (composite header, Flow widget bubbles + Split/Full + chevron, Pack Runner `change ›`). **One PR.**
2. Add `Tooltip--Rich`. No call-site change yet; just the API.
3. Add `Tooltip--Popover`. Walkthrough prerequisite.
4. Ship `Tooltip-Walkthrough` with the first three milestones (everything Phases 1-5 shipped).

## Open questions documented in the spec

- Component vs. action directive (lean: component, because the family has multiple variants).
- Position engine — `floating-ui` (~10kB gz) vs. hand-rolled `getBoundingClientRect` shim (lean: `floating-ui` for the diagonal cases + arrow geometry).
- Touch default — long-press vs. always-visible secondary text.
- Milestone registry location — per-app vs. shared-ui.

## Files

- `context-v/specs/Tooltip-System.md` — rewritten; v0.0.0.1 → v0.0.0.2.
- `context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md` — §8 annotation + Wish list entry rewritten to lead with family + walkthrough; v0.0.1.1 → v0.0.1.2.

## Related

- Spec: `context-v/specs/Shell-and-Micro-Frontend-UX-Coherence.md` §Cross-cutting principles §8 + §Wish list
- Spec: `context-v/specs/Tooltip-System.md`
- Spec: `context-v/specs/Initial-User-Experience.md` — the walkthrough is the first-run mechanic this spec needs
- Blueprint: `context-v/blueprints/Augment-It-as-Working-App-and-Architecture-Demo.md` — `audience` branching reaches the user through the walkthrough
- Prior PRs: #6, #7, #8, #9, #10, #11, #12, #13, #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)