### PR TITLE
feat(workspaces): tenant primitive — header switcher, per-tenant .env + rows.json, row-store re-scopes on toggle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "clients/reach-edu"]
 	path = clients/reach-edu
 	url = https://github.com/lossless-group/augment-reach-edu.git
+[submodule "clients/humain-vc"]
+	path = clients/humain-vc
+	url = https://github.com/lossless-group/humain-vc-data.git

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ augment-it/
 │   ├── prompt-template-manager/ :3003 # Custom-prompt authoring (paired with pack-runner)
 │   ├── request-reviewer/        :3004 # Pre-flight review of fan-out plans
 │   ├── response-reviewer/       :3005 # By-record triage cockpit (post-flight)
-│   ├── chat/                    :3006 # In-app chat verb surface (v0.0.1)
+│   ├── chat/                    :3006 # In-app chat verb surface (/inbox lands URLs as corpus)
 │   ├── pack-runner/             :3009 # Source-bound pack invocation (paired with PTM)
+│   ├── sort-filter-lens/        :3013 # First Lens — sort/filter/inline-edit over the active record set
 │   ├── highlight-collector/           # planned — collect highlights from AI responses (scaffold)
 │   └── insight-manager/               # planned — manage insights across responses (scaffold)
 │
@@ -50,10 +51,11 @@ augment-it/
 │   ├── ingest/                        # CSV → record_set.create (dynamic schema from headers)
 │   ├── xlsx-ingest/                   # XLSX workbook → record_set.create (same shape as CSV)
 │   ├── workspace/                     # Browser-facing capabilities router
-│   ├── row-store/                     # Rows, record sets, promote-fold, row.fields write-back (+ socials)
+│   ├── row-store/                     # Rows, record sets, promote-fold, row.fields write-back (+ socials, predecessor lineage)
 │   ├── prompt-store/                  # Persists custom prompt templates
 │   ├── prompt-runner/                 # Anthropic, custom prompts, per-row fan-out
 │   ├── response-store/                # Sibling payload (prose + structured Candidate)
+│   ├── content-ingest/                # Funder-content corpus: Jina-extracted .md + binary PDFs, record_uuid + published_at stamping, /promote-snapshot
 │   └── social-search/                 # Pack search/fan-out, pluggable connectors (SearXNG default, Tavily peer)
 │
 ├── packages/                          # Shared code
@@ -72,8 +74,9 @@ augment-it/
 │   ├── reminders/                     # Session pickup notes
 │   └── issues/                        # Filed-but-not-yet-executed decisions
 │
+├── clients/                           # Per-tenant corpus trees (git submodules); funder dirs hold .md + binary PDFs
 ├── changelog/                         # Ship log — every coherent build session writes one
-├── scripts/                           # dev.sh, backup-stores.sh
+├── scripts/                           # dev.sh, backup-stores.sh, backfill-corpus-{record-uuid,published-at}.mjs
 ├── docker-compose.yml                 # NATS + services
 ├── turbo.json
 ├── pnpm-workspace.yaml
@@ -87,6 +90,9 @@ augment-it/
 - **Sibling-payload responses.** Every response record carries both prose AND an optional structured `Candidate` (url, display_name, confidence 0–100, snippet, source_metadata), plus an `outcome` enum (`found | not_found | error | skipped | pending`). The renderer in Response Reviewer branches on outcome.
 - **Inline correction + human-supply on one surface.** The by-record view in Response Reviewer lets the user edit URLs, edit display_names, edit entity-names (the row's identity column), or supply a URL the pack didn't find — all riding the same `response.set_structured` subject.
 - **Federation-host shell.** The shell handles peek-deck tile rotation, co-existence (50/50 splits), paired-only remotes (`pack-runner`, `chat` — not in the rotation, reached via the `augment-it:navigate` event), and runtime cross-remote communication via `window` events + localStorage.
+- **Lenses.** A *lens* is a federated remote that re-presents the active record set under a different affordance shape — sort/filter, inline-edit, per-row corpus add — without leaving the record. `sort-filter-lens` is the first; registered as a third member of `AUGMENT_COMPOSITE` alongside PTM + Pack Runner. Lenses auto-fall-back to the newest non-archived record set when localStorage points at an archived one, so they survive `/promote-snapshot` cleanly.
+- **Funder-content corpus.** Per-client, per-funder directory of source materials backing each row. Two entry vectors land into the same shape: the chat `/inbox <url>` verb (with active-client context) and the per-row inline "+ URL" affordance in the lens. Both run fire-and-forget through `services/content-ingest/`, Jina-extract markdown, preserve original PDFs as LFS binaries, and stamp `record_uuid` + `published_at` into frontmatter. Manual-paste URLs land regardless of domain (operator curation trumps the same-host rule, which only binds pack outputs).
+- **Corpus chips tell the truth.** `corpus.list_for_record` joins by `corpus_funder_slug` as primary (one dir scan) with `record_uuid` lineage as fallback — chips stay accurate across `/promote-snapshot` cuts. `/promote-snapshot` itself derives `corpus_*` columns from filesystem state when cutting a new record set, and stitches `predecessor_record_set_id` for lineage walks.
 
 ## Setup
 

--- a/apps/chat/src/ChatSurface.svelte
+++ b/apps/chat/src/ChatSurface.svelte
@@ -100,11 +100,22 @@
 
   // Send context — what the user is looking at right now. The server
   // inlines this in the prompt so the model can pick a record_set_id
-  // for prompt.draft without asking.
-  const sendContext = $derived(
-    workspace.activeView.kind === 'record_set'
-      ? { record_set_id: workspace.activeView.record_set_id }
-      : undefined,
+  // for prompt.draft without asking. `client_id` is the active workspace,
+  // forwarded on every turn so the chat slab knows which tenant we're in
+  // without holding the value process-wide.
+  const sendContext = $derived<{
+    focused_prompt_id?: string;
+    record_set_id?: string;
+    client_id?: string;
+  } | undefined>(
+    (() => {
+      const ctx: { record_set_id?: string; client_id?: string } = {};
+      if (workspace.activeView.kind === 'record_set') {
+        ctx.record_set_id = workspace.activeView.record_set_id;
+      }
+      if (workspace.active_client_id) ctx.client_id = workspace.active_client_id;
+      return Object.keys(ctx).length ? ctx : undefined;
+    })(),
   );
 
   async function send(): Promise<void> {

--- a/apps/chat/src/chat-state.svelte.ts
+++ b/apps/chat/src/chat-state.svelte.ts
@@ -41,7 +41,7 @@ class ChatState {
    * The propose / invoke branches don't auto-act — the surface renders
    * affordances and the user clicks to accept.
    */
-  async sendMessage(message: string, context?: { focused_prompt_id?: string; record_set_id?: string }): Promise<void> {
+  async sendMessage(message: string, context?: { focused_prompt_id?: string; record_set_id?: string; client_id?: string }): Promise<void> {
     if (this.sending) return;
     if (!message.trim()) return;
     const id = `t_${Date.now().toString(36)}`;

--- a/apps/record-collector/src/App.svelte
+++ b/apps/record-collector/src/App.svelte
@@ -63,6 +63,18 @@
       onStatus: (s) => (status = s),
     });
     void refreshList();
+    // Re-fetch when the operator toggles workspaces in the shell header.
+    // The workspace singleton clears its cached record_sets/rows before
+    // this fires; row-store's NATS subscriber has already swapped to the
+    // new tenant's file by the time the browser reaches this point.
+    const onWorkspaceChange = () => {
+      selectedId = null;
+      void refreshList();
+    };
+    window.addEventListener('augment-it:workspace-changed', onWorkspaceChange);
+    return () => {
+      window.removeEventListener('augment-it:workspace-changed', onWorkspaceChange);
+    };
   });
 
   async function refreshList() {

--- a/apps/sort-filter-lens/src/App.svelte
+++ b/apps/sort-filter-lens/src/App.svelte
@@ -442,8 +442,17 @@
       }
     };
     window.addEventListener('augment-it:active-record-set-changed', onActiveRecordSetChange);
+    // Re-fetch when the operator toggles workspaces in the shell header.
+    // The lens drops its selection and re-loads the record-set list from
+    // the new tenant's row-store. See [[Workspaces-as-Tenant-Primitive]].
+    const onWorkspaceChange = (): void => {
+      selectedRecordSetId = null;
+      void loadRecordSets();
+    };
+    window.addEventListener('augment-it:workspace-changed', onWorkspaceChange);
     return () => {
       window.removeEventListener('augment-it:active-record-set-changed', onActiveRecordSetChange);
+      window.removeEventListener('augment-it:workspace-changed', onWorkspaceChange);
     };
   });
 

--- a/changelog/2026-06-11_02_Workspaces-Tenant-Primitive-Baby-Step-One.md
+++ b/changelog/2026-06-11_02_Workspaces-Tenant-Primitive-Baby-Step-One.md
@@ -1,0 +1,166 @@
+---
+title: "Workspaces become a tenant primitive — top-right switcher in the shell, per-workspace `.env` loaded scoped (not into `process.env`), `client_id` flows through every chat turn, hardcoded reach-edu retires"
+lede: "augment-it was filing all its work under one tenant (reach-edu) and the slab that told the chat what `client_id` to use literally hardcoded the string. Tonight that ends. The shell grows a workspace switcher in the top-right of the header that lists every directory found under `clients/` (today: humain-vc, reach-edu), and clicking one persists the choice to localStorage, broadcasts it via `augment-it:workspace-changed`, and tells the workspace-service which `client_id` is process-wide active. The chat slab now reads the operator's pick from `ctx.client_id` (forwarded on every chat turn) and falls back to the server's process-wide active value — the hardcoded reach-edu string is gone. The load-bearing piece is the env-var seam: `clients/<slug>/.env` gets loaded into a frozen, in-memory map keyed by slug at workspace-service boot. We deliberately do NOT merge into `process.env` because the workspace-service runs in one process and serves all tenants — `process.env` would bleed Decile keys from humain-vc into a reach-edu chat turn. The connector-config seam (LLM / search / CRM / MCP / storage) the spec calls for lands in step 2; tonight surfaces the raw env, hides nothing, and gives Decile a clean home to slot into next."
+publish: true
+date_created: 2026-06-11
+date_modified: 2026-06-11
+authors:
+  - Michael Staton
+augmented_with:
+  - Claude Code on Claude Opus 4.7 (1M context)
+tags:
+  - Augment-It
+  - Workspaces
+  - Tenant-Boundary
+  - Shell-Chrome
+  - Workspace-Switcher
+  - Env-Var-Seam
+  - Multi-Tenant
+  - Humain-VC
+  - Reach-Edu
+  - Baby-Step
+semver: 0.0.1
+---
+
+# Workspaces as tenant primitive — baby step 1
+
+## Why care
+
+Until tonight, augment-it knew about exactly one client and the knowledge
+was three layers deep: hardcoded in the chat slab as the literal string
+`reach-edu`, implicit in every `clients/<id>/` filesystem path callers
+typed by hand, and silent in the operator's head as "the only one." The
+moment a second client (humain-vc) showed up — different funder list,
+different corpus, different CRM (Decile, with its own API keys) — the
+operator had to choose between trampling reach-edu's state every time
+they switched, or carrying two checkouts. Neither is sustainable.
+
+The fix is a tenant primitive — a **workspace** — that the operator
+toggles between in the shell header. Every service that already takes a
+`client_id` argument now gets it from the operator's pick, and the per-
+workspace `.env` lands in a scoped, frozen map so adding humain-vc's
+Decile keys doesn't bleed into a reach-edu chat turn.
+
+## What's new
+
+**Shell header workspace switcher (top-right).** A pill button next to
+the chat/mode toggles shows the active workspace's display name; click
+opens a menu listing every directory found under `clients/`, with the
+active row checked, slug shown in mono underneath, and an `env` chip
+when a `.env` is present. Click a row to switch. The choice persists to
+`localStorage` (`augment-it:active-client-id`) and broadcasts
+`augment-it:workspace-changed` so other remotes (chat first; lenses next)
+update without polling.
+
+**Workspace-service grew a registry.** New module `services/workspace/
+src/workspaces.ts` discovers workspaces by scanning `CLIENTS_ROOT` (env
+var; `/clients` in docker, `../../clients` in local dev). Each immediate
+child directory IS a workspace; no manifest required. Three new
+capabilities served locally (no NATS round-trip — workspace-service owns
+this state):
+
+- `workspace.list` → `{ workspaces: [{client_id, display_name, has_env}], active_client_id }`
+- `workspace.activate` → set the process-wide active slug + return the summary
+- `workspace.active` → just the active slug
+
+Capability dispatch (`services/workspace/src/capabilities.ts`) checks a
+`LOCAL_CAPABILITIES` map before falling through to the NATS path, so the
+WebSocket invoke surface stays uniform for the browser.
+
+**Per-workspace `.env` loaded scoped.** At boot, the registry reads
+`clients/<slug>/.env` (when present) into a frozen `Record<string, string>`
+keyed by slug. The minimal parser handles `KEY=value`, `#` comments,
+single/double quoted values, and skips blank lines — no expansion (which
+would only cause surprise in a per-tenant context). The map is held in
+the workspace-service process and **not** merged into `process.env` —
+that would bleed Decile credentials across tenants the moment any
+service downstream reads from `process.env` at dispatch time.
+
+**The chat slab stops lying.** `services/workspace/src/chat.ts` no longer
+hardcodes "reach-edu." The slab reads `ctx.client_id` from the chat turn
+(forwarded by the chat surface from `workspace.active_client_id`), falls
+back to the server's process-wide active slug, and refuses client-scoped
+capabilities when both are null. The wire field stays `client_id` —
+lived-with naming collision with the prior `Workspace Service` substrate
+plan, resolved in prose at the top of `[[Workspaces-as-Tenant-Primitive]]`.
+
+**Workspace package grew an active-client surface.** `@augment-it/
+workspace` exposes `workspace.workspaces`, `workspace.active_client_id`,
+`workspace.loadWorkspaces()`, and `workspace.activateWorkspace(id)`.
+Each federation remote gets its own singleton (no shared block in the
+shell's rsbuild config); a window-event listener in the constructor keeps
+every remote's `active_client_id` in sync when any switcher fires. The
+chat surface's `sendContext` derived value automatically includes
+`client_id` on every chat turn.
+
+**Docker-compose mounts `clients/` read-only into workspace-service.**
+Volume `./clients:/clients:ro`. The same mount that content-ingest
+already had now extends to the workspace-service.
+
+## How it works
+
+```
+clients/                            (the registry — directories are workspaces)
+├── humain-vc/                      (alphabetical first → default active)
+│   ├── .env                        DECILE_API_KEY=… DECILE_API_BASE_URL=…
+│   └── .gitignore                  guards its own .env
+└── reach-edu/                      (the prior single tenant; still works)
+    ├── corpus/                     existing per-funder dirs
+    ├── inputs/                     existing CSV snapshots
+    └── …
+```
+
+```
+boot ──▶ workspace-service reads CLIENTS_ROOT, discovers slugs, loads .envs
+         into a frozen Map<slug, env>; sets active = ACTIVE_CLIENT_ID env
+         or first slug alphabetically (humain-vc)
+
+shell ──▶ WorkspaceSwitcher mounts; onMount fires workspace.list; the
+         persisted localStorage pick is reconciled against what exists
+         on disk (gracefully falls back to server's active if the
+         persisted slug is gone — same shape as Sort & Filter Lens'
+         archived-set fallback)
+
+click ──▶ workspace.activate(client_id) → server flips its active value,
+         singleton persists to localStorage, dispatches WORKSPACE_CHANGED_EVENT;
+         chat remote (separate singleton) listens for the event, updates
+         its own active_client_id reactively
+
+chat ──▶ every chat_turn now includes context.client_id; chat.ts in the
+         workspace-service reads it directly into the contextSlab; the
+         model sees "The active client is: humain-vc" and routes
+         corpus.inbox.add / pipeline.promote_snapshot with the right slug
+```
+
+## What's still loose
+
+- **Connector-config seam** (the next baby step). The spec calls for a
+  typed `ConnectorRegistry` — `llm | search | crm | mcp | storage` — that
+  resolves from the raw env map per prefix (`DECILE_*` → `crm.decile`,
+  `ANTHROPIC_*` → `llm.anthropic`, etc.). Tonight surfaces the raw env;
+  the typed resolver lands next.
+- **`workspace_slug` on every NATS envelope.** Today the slug rides only
+  on chat turns and the explicit `client_id` arg on existing capabilities
+  (`corpus.add`, `pipeline.promote_snapshot`). The spec calls for it on
+  every envelope so a future audit log has a single place to read tenancy.
+- **humain-vc tracking decision.** `clients/humain-vc/` is currently
+  untracked. The workspace-service discovers it from disk regardless, but
+  the operator should decide whether to mirror the reach-edu pattern
+  (submodule) or commit in-tree.
+- **`.env` hot reload.** The registry primes at boot. Editing
+  `clients/humain-vc/.env` requires a restart today; a file-watcher lands
+  whenever the connector seam gives it something to do.
+- **Per-workspace theme, RBAC, audit log, registration flow.** All named
+  in the spec's "Terminal vision" section as explicit later moves.
+- **Sibling pillar apps (`memopop-ai`, `dididecks-ai`) adopting the same
+  contract.** The shape is shared; the inheritance is per-pillar on each
+  pillar's own schedule. `packages/workspace/` graduates to `ai-labs/
+  packages/workspace/` when the second pillar picks it up.
+
+## See also
+
+- [[Workspaces-as-Tenant-Primitive]] — the spec this implements
+- [[Cloud-Variant-of-Dididecks-AI-Workspace]] — the cross-cutting
+  exploration that informed the privacy/adapter framing
+- [[Augment-It-Workspace-Walking-Skeleton]] — the prior plan whose
+  "Workspace Service" name lives alongside this one (intentionally)

--- a/context-v/specs/Workspaces-as-Tenant-Primitive.md
+++ b/context-v/specs/Workspaces-as-Tenant-Primitive.md
@@ -1,0 +1,406 @@
+---
+title: "Workspaces as Tenant Primitive — toggling, tenant-aware microservices, per-tenant env-var pickup, and the seam that lets MCPs and connectors vary per client"
+lede: "Augment-It (and, by inheritance, its sibling pillar apps memopop-ai and dididecks-ai) needs a tenant primitive named workspace — the boundary that says 'humain-vc' vs 'reach-edu' vs whoever comes next. The terminal state is rich: per-workspace branded theme, team membership, roles + permissions, registration flow, auth, per-tenant choice of LLM provider / CRM / MCP server / search connector / storage destination. We are filesystem-backed and local right now, so this spec lays out the vision once and then scopes baby step 1 down to its bones: a workspace toggle, a workspace-aware envelope on every microservice request, I/O routing to `clients/<slug>/`, and a per-workspace `.env` pickup that resolves through a connector-config seam designed to absorb Decile-shaped (and future MCP-shaped, future LLM-shaped) per-tenant integrations without re-design. Inspired by [[Cloud-Variant-of-Dididecks-AI-Workspace]] but diverges on storage (filesystem-now vs cloud) and on cross-cutting reach (this is the contract sibling pillar apps inherit, not a dididecks-only artifact)."
+date_created: 2026-06-11
+date_modified: 2026-06-11
+authors:
+  - Michael Staton
+augmented_with:
+  - Claude Code on Claude Opus 4.7 (1M context)
+semantic_version: 0.0.0.1
+tags:
+  - Spec
+  - Augment-It
+  - Workspaces
+  - Tenant-Boundary
+  - Multi-Tenant
+  - Connector-Config
+  - Env-Var-Adapter
+  - Filesystem-Backed
+  - Cross-Cutting-Pillar-Contract
+  - Humain-VC
+  - Reach-Edu
+status: Draft
+---
+
+# Workspaces as Tenant Primitive
+
+## What this spec is
+
+This spec defines the **workspace** as the tenant boundary inside augment-it,
+pins the long-arc vision so future feature work has a target to compose against,
+and scopes baby step 1 down to a filesystem-only walking version that is
+genuinely small but does not paint future steps into a corner. Sibling pillar
+apps in `ai-labs/` — `memopop-ai` and `dididecks-ai` — adopt the same shape
+later via the same contract; this spec is the cross-cutting one even though
+the implementation lands first in augment-it.
+
+It is **inspired by** [[Cloud-Variant-of-Dididecks-AI-Workspace]] and reuses
+that exploration's privacy-properties table as a forward-looking constraint,
+but it diverges in two ways the reader should know up front:
+
+1. **Storage:** the cloud-variant exploration is reasoning about S3 + KMS +
+   Postgres RLS. This spec is filesystem-backed (`clients/<slug>/`) because
+   that is the actual current ground truth. The seam is designed so the
+   cloud-variant's adapters can be slotted in later without re-cutting the
+   workspace contract.
+2. **Scope:** the cloud-variant exploration is dididecks-only. This spec is
+   the cross-cutting contract — workspace is the tenant primitive across all
+   three pillar apps. The shape has to be sharable.
+
+## Name collision (lived with, not renamed)
+
+There is a prior plan, [[Augment-It-Workspace-Walking-Skeleton]], that uses
+the word **workspace** in a different sense — the singular architectural
+substrate (Svelte 5 singleton + Node/Fastify Workspace Service + NATS bus)
+that holds row state for the running app. That substrate shipped.
+
+This spec uses **workspace** to mean **tenant boundary** — one of many
+per running app, the thing the operator toggles between to switch from
+humain-vc to reach-edu.
+
+Both meanings live. Resolution is in prose where ambiguity matters:
+
+- The prior plan's **Workspace Service** (the container) keeps its name; it
+  is the runtime substrate that now also has to become tenant-aware.
+- This spec's **workspace** (lowercase, the tenant) is the new concept; every
+  occurrence of "workspace" below means *tenant boundary* unless explicitly
+  qualified.
+- When we need to disambiguate in code, we use `tenant_slug` / `workspace_slug`
+  as the field name on the wire (substrate-irrelevant) and `WorkspaceService`
+  (PascalCase, container name) for the substrate component.
+
+This is deliberate — see [[feedback_context_v_evolves_in_prose]]. The context-v
+record carries the evolution; we do not rewrite history to dodge a name
+collision.
+
+## Terminal vision (what workspaces eventually do)
+
+Locked here so baby step 1 does not foreclose any of it. None of the following
+ships in baby step 1; it ships in named later steps.
+
+1. **Tenant identity.** A workspace is the unit of "whose data am I working
+   in right now." Every record set, every corpus directory, every fire, every
+   response, every audit-log entry, every env-var resolution is workspace-
+   scoped.
+2. **Team membership, roles, permissions.** A workspace has members; members
+   have roles; roles confer permissions. The admin surface for managing this
+   lives inside the workspace, governed by an `admin` role. Default roles:
+   `admin`, `editor`, `viewer`. Permissions are capability-gated at the
+   workspace boundary, not at the record-set level.
+3. **Registration and auth flow.** A user signs up, joins or creates a
+   workspace, and from then on every session is workspace-bound. Switching
+   workspaces is a first-class action — not a re-login but a context switch.
+   Inherits from [[Install-Auth-Across-Applied-AI-Labs-Apps]] (the auth
+   blueprint) once that lands.
+4. **Per-workspace branded theme.** Each workspace controls design tokens
+   (colors, typography, spacing) via a `theme.css` override layered on top
+   of the shipping three-mode theme system. Inherits from the `theme-system`
+   skill's two-tier-token discipline.
+5. **Per-workspace connector configuration.** The headline mechanic. A
+   workspace declares which LLM provider it uses, which CRM (Decile,
+   HubSpot, Salesforce, custom), which MCP servers (Gmail, Drive, GitHub,
+   custom), which search providers (SearXNG, Tavily, SerpApi), which storage
+   destination (filesystem-now, S3, Powabase later). Each connector reads
+   from the workspace's `.env` namespace and is resolved at request time.
+6. **Cross-cutting across pillar apps.** memopop-ai and dididecks-ai adopt
+   the same workspace contract. A user with workspaces `humain-vc` and
+   `reach-edu` sees the same toggle in every pillar app; the active
+   workspace is shared across apps in the same session.
+7. **Tamper-evident audit log.** Every workspace-scoped operation writes
+   to an append-only log inside the workspace (`clients/<slug>/audit/`)
+   keyed by user + capability + payload-hash + timestamp. Filesystem-first;
+   moves to a separate trust boundary when the cloud variant arrives.
+8. **Termination and export.** Deleting a workspace deletes its
+   `clients/<slug>/` tree (modulo retention). Exporting a workspace is a
+   zip of the same tree. Filesystem-now makes both trivial; the seam stays
+   the same when storage moves.
+
+Items 2–4 and 7–8 are explicitly **out of scope** for baby step 1. They are
+named here so the seam designed in step 1 absorbs them later without re-cut.
+
+## Why filesystem-first
+
+Stated plainly so future agents do not skip to the cloud shape prematurely:
+
+- Local-fs makes the privacy properties from the cloud-variant exploration's
+  table mostly free; we should consume that gift while it is on offer.
+- A DB schema for workspaces invites premature commitment to RBAC tables,
+  membership tables, audit tables before the connector-config seam is
+  exercised against real per-tenant integrations.
+- The operator (the human) is currently the only user; multi-user / auth
+  arrives later and the shape it takes is informed by what the connector
+  seam produces, not the other way around.
+- `clients/<slug>/.env` is already the working convention (humain-vc has one;
+  reach-edu has one). Designing toward what already works beats inventing
+  a workspace-config DB.
+
+## Baby step 1 — scope
+
+The smallest end-to-end version that exercises the workspace primitive
+through every layer of the existing stack. Five mechanics, all filesystem-
+backed, none of them admin-grade.
+
+### 1. Workspace registry (filesystem-discovered)
+
+`clients/` is the registry. Each immediate child directory is a candidate
+workspace. A workspace exists when its directory exists and contains at
+minimum:
+
+```
+clients/<slug>/
+├── .env                    # per-workspace environment, gitignored
+├── .gitignore              # at minimum guards .env
+└── (corpus/, inputs/, outputs/ created lazily)
+```
+
+No `workspace.json` manifest, no registry DB. The directory IS the workspace.
+A future step adds a `clients/<slug>/workspace.yaml` for display name, theme
+overrides, member list — but baby step 1 derives display name from the slug
+(title-case-with-dashes-broken).
+
+### 2. Active workspace, persisted
+
+The shell holds `active_workspace_slug` in localStorage. On boot, the shell:
+
+1. Reads the persisted slug.
+2. If it points to a directory that no longer exists, falls back to the
+   first slug in alphabetical order (`humain-vc` today; resilient to additions).
+3. Publishes `workspace.active.changed` on the NATS bus so every service
+   that holds workspace-scoped state can react.
+
+Following the pattern from [[dffaac6 — Sort & Filter Lens auto-falls-back]] —
+when localStorage points at a now-gone target, fall back gracefully.
+
+### 3. Toggle UI
+
+A workspace switcher lives in the shell chrome — not inside any single
+remote. Minimum shape:
+
+- A button or chip showing the active workspace's display name.
+- Click → dropdown of all discovered workspaces.
+- Selecting one fires `workspace.activate` on the workspace-service.
+- The shell broadcasts the change; remotes that care re-render against the
+  new context.
+
+No design tokens shift in baby step 1 — the theme stays the shipping
+three-mode default. Per-workspace theme is item 4 of the terminal vision and
+is explicitly later.
+
+### 4. Tenant-aware envelope on every microservice request
+
+Every NATS message envelope gains a required field:
+
+```jsonc
+{
+  "kind": "invoke",
+  "id": "inv_abc123",
+  "workspace_slug": "humain-vc",
+  "capability": "row.list",
+  "args": { ... }
+}
+```
+
+`WorkspaceService` (the container) injects `workspace_slug` from the
+session's active workspace on every outbound NATS request. Domain services
+treat unscoped requests as a programming error and refuse them with a clear
+log line — not a runtime crash, but a refusal that makes the missing-slug
+case loud.
+
+Implication for existing handlers:
+
+- `services/content-ingest/` — `corpus.list_for_record`, `corpus.add`,
+  `corpus.list_for_record`, `promote-snapshot` — all gain a `workspace_slug`
+  parameter and resolve paths against `clients/<slug>/corpus/` instead of
+  the hardcoded one.
+- `services/row-store/` — record sets are workspace-scoped; the JSON store
+  becomes per-workspace (`clients/<slug>/rows.json` or `data/<slug>/rows.json`,
+  TBD in implementation phase).
+- `services/social-search/`, `services/prompt-runner/`,
+  `services/response-store/`, `services/ingest/`, `services/xlsx-ingest/`
+  — each receives `workspace_slug` and uses it to scope state and to
+  resolve connector configuration (see § 5).
+
+### 5. Per-workspace `.env` pickup via a connector-config seam
+
+The load-bearing design moment of baby step 1. Done well, the rest of the
+vision composes onto it; done thoughtlessly, every future integration
+re-cuts the wire.
+
+#### The seam
+
+A workspace's `.env` is loaded into a **scoped config object** keyed by
+workspace slug, NOT merged into `process.env`. Merging into `process.env`
+would create cross-workspace bleed the moment we have two workspaces active
+in the same Node process (which we do, because `WorkspaceService` serves
+all sessions).
+
+```ts
+// packages/workspace/src/config.ts
+export interface WorkspaceConfig {
+  slug: string;
+  env: Readonly<Record<string, string>>;     // raw .env contents, frozen
+  connectors: ConnectorRegistry;             // resolved typed connectors
+}
+
+export interface ConnectorRegistry {
+  llm?:     LLMConnectorConfig;     // anthropic | openai | local | ...
+  search?:  SearchConnectorConfig;  // searxng | tavily | serpapi | ...
+  crm?:     CRMConnectorConfig;     // decile | hubspot | salesforce | ...
+  mcp?:     MCPConnectorConfig[];   // arbitrary set of MCP servers
+  storage?: StorageConnectorConfig; // filesystem | s3 | powabase | ...
+}
+```
+
+Services do not read `process.env.ANTHROPIC_API_KEY` directly. They request
+the workspace's resolved `connectors.llm` from `WorkspaceService` (in-process
+when running together, via NATS request/reply when separated).
+
+#### The Decile worked example
+
+`clients/humain-vc/.env` contains:
+
+```sh
+DECILE_API_BASE_URL=https://api.decile.example/v1
+DECILE_API_KEY=...
+DECILE_TENANT_ID=...
+```
+
+The connector resolver maps the `DECILE_*` prefix to a `crm` connector of
+kind `decile`. A future `crm.list_deals` capability dispatches against
+`workspace.connectors.crm` — when the active workspace is `humain-vc` it
+resolves to the Decile config; when the active workspace is `reach-edu`
+(which does not have Decile configured) it returns `null` and the capability
+publishes a `crm.not_configured` event instead of erroring.
+
+The pattern generalizes: every connector kind has a **prefix or set of
+prefixes** in the env namespace, a **resolver** that maps from prefix to
+typed config, and a **fallback** of either another configured provider or
+`not_configured`. Adding a new CRM (HubSpot) is: register the `HUBSPOT_*`
+prefix, write the resolver, ship.
+
+#### What the seam buys us
+
+- Decile lands without touching any other client's behavior.
+- A new MCP server (say, Gmail for one client, Drive for another) is a
+  registry entry, not a rewrite.
+- The cloud-variant's "per-workspace KMS keys" property has a place to live
+  later — the resolver gains a "fetch from KMS" branch alongside the
+  "read from .env" branch.
+- The `connectors` object is the *only* surface domain services read
+  workspace-scoped configuration from. That makes the audit story tractable:
+  every connector access can be logged at the resolver, not at every caller.
+
+### Migration: reach-edu → humain-vc as primary
+
+The submodule pointer on `rebuild/turbo-rsbuild` is currently
+`clients/reach-edu`. Baby step 1 makes `humain-vc` the default active
+workspace (alphabetically first; matches the user's stated intent of
+building humain-vc functionality first and back-porting to reach-edu).
+
+Concretely:
+
+- `clients/humain-vc/` is committed to the repo (currently untracked with
+  `.env` + `.gitignore`). Submodule or in-tree TBD by the
+  pseudomonorepos relocation discipline — `.env` is sensitive, must be
+  backed up before any move.
+- `clients/reach-edu/` (submodule) stays where it is; loses primacy but
+  not presence.
+- The toggle defaults to humain-vc on a fresh localStorage; users who had
+  reach-edu active retain it (the persisted slug survives the change).
+
+## What is explicitly NOT in baby step 1
+
+- Auth, registration, sessions tied to humans. The "active workspace" is
+  per-browser, not per-user.
+- RBAC, roles, permissions. The operator is the only role.
+- Per-workspace theme. The three-mode theme is unchanged.
+- Audit log. The seam exists at the connector resolver; the writer doesn't.
+- Cross-app workspace sync (sibling pillar apps inheriting the same
+  active-workspace context). The contract is shared; the inheritance
+  ships per-app, on each pillar's own schedule.
+- A workspace-creation UI. Workspaces are created by `mkdir
+  clients/<slug>/` and dropping a `.env` in. The toggle picks them up
+  on next boot.
+- Connector kinds beyond the registry shape. The `LLMConnectorConfig`,
+  `SearchConnectorConfig`, etc. types are declared and at least one is
+  exercised end-to-end (likely `search` via the existing SearXNG +
+  Tavily seam, since that code already exists). Decile is the design
+  target for the *next* step's worked example, not the one baby step 1
+  has to ship working.
+
+## Forward inheritance — sibling pillar apps
+
+memopop-ai and dididecks-ai are explicit consumers of this contract. The
+shared parts live in `packages/workspace/` inside augment-it; they
+graduate to `ai-labs/packages/workspace/` (a shared package) when the
+second pillar app picks them up. Until then, the contract is exercised
+in augment-it, with copies-for-now allowed in the other pillars if their
+own walking-skeletons land before extraction.
+
+What inherits:
+
+- The `WorkspaceConfig` and `ConnectorRegistry` interfaces.
+- The `workspace_slug`-on-every-envelope discipline.
+- The `clients/<slug>/.env` convention (or each app's equivalent root —
+  memopop-ai may use `users/<slug>/`, dididecks-ai may use
+  `client-sites/<slug>/`; the *seam* is shared, the *root directory name*
+  is per-app).
+- The `workspace.active.changed` event semantics.
+
+What does not need to be shared:
+
+- The toggle UI (each app has its own shell chrome).
+- The fallback rules (each app may have a different "first" workspace).
+
+## Open questions
+
+- **Same-session multi-workspace.** Can a single browser tab hold two
+  workspaces open side-by-side (e.g., comparing humain-vc and reach-edu
+  in a split view)? Baby step 1 assumes no — one active workspace per
+  session. If yes becomes a requirement, the WS-envelope `workspace_slug`
+  scales fine, but the shell's "active" notion has to fork into "active
+  per pane."
+- **Per-workspace data files inside `clients/<slug>/`.** Today the corpus
+  lives there but the row-store JSON lives in `services/row-store/data/`.
+  Does the row-store JSON move into `clients/<slug>/rows.json` so the
+  workspace is truly self-contained on disk? Lean yes; makes export and
+  termination trivial. Decide in implementation.
+- **`.env` reloading without restart.** When the operator edits
+  `clients/humain-vc/.env` to add a Decile key, do we expect them to
+  restart the stack or do we file-watch and re-resolve? Lean toward
+  file-watch for the dev experience; trivial with `chokidar`. Worth
+  pinning in the implementation plan.
+- **What happens when a workspace's `.env` references a secret store**
+  (1Password CLI, `op://...` URLs) instead of plain values? The resolver
+  has a clean place to grow that branch. Out of scope to build now; in
+  scope to not foreclose.
+- **Where does the toggle live in dididecks-ai and memopop-ai?** The
+  shell chrome differs across pillars. Likely each pillar reuses a
+  shared component but mounts it in its own chrome. Confirm when the
+  second pillar adopts.
+- **Theme override loading.** When per-workspace theme arrives, where
+  do the override tokens live — `clients/<slug>/theme.css` (filesystem)
+  or a `theme:` block in `clients/<slug>/workspace.yaml`? The
+  `maintain-design-md` skill prefers prose-with-frontmatter; aligns
+  toward the YAML option.
+
+## See also
+
+- [[Augment-It-Workspace-Walking-Skeleton]] — the prior plan whose
+  "workspace" names the architectural substrate (lived-with collision).
+- [[Cloud-Variant-of-Dididecks-AI-Workspace]] — the exploration this
+  spec is inspired by; the privacy-properties table is the forward
+  constraint the connector seam has to absorb when storage moves
+  off filesystem.
+- [[Funder-Content-Corpus-Workflow]] — the corpus convention that
+  established `clients/<slug>/corpus/` as the per-tenant content root;
+  this spec generalizes that pattern from corpus-only to all per-tenant
+  state.
+- [[Install-Auth-Across-Applied-AI-Labs-Apps]] — the auth blueprint
+  the workspace's eventual identity/RBAC layer inherits from.
+- [[Per-App-Workspace-Conventions]] — the parent blueprint the prior
+  walking-skeleton plan instantiated; this spec extends with the
+  tenant-boundary dimension.
+- [[feedback_context_v_evolves_in_prose]] — why the name collision
+  with the prior plan is left in place.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,16 @@ services:
       - nats
     environment:
       NATS_URL: nats://nats:4222
-      ROW_STORE_PATH: /data/rows.json
+      # Workspace-scoped: rows.json now lives at /clients/<slug>/rows.json
+      # per [[Workspaces-as-Tenant-Primitive]]. CLIENTS_ROOT mirrors the
+      # workspace-service convention. LEGACY_ROW_STORE_PATH triggers a
+      # one-shot copy of the pre-workspace single-tenant file into the
+      # active workspace on first boot; safe to keep set after migration.
+      CLIENTS_ROOT: /clients
+      LEGACY_ROW_STORE_PATH: /data/rows.json
     volumes:
       - row-store-data:/data
+      - ./clients:/clients
 
   ingest:
     build: ./services/ingest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,17 @@ services:
 
   row-store:
     build: ./services/row-store
+    # depends_on workspace-service so the migration on first boot lands
+    # under the right tenant slug. row-store queries workspace-service's
+    # workspace.active.requested over NATS at boot; without ordering, the
+    # request can fire before workspace-service has subscribed and the
+    # retry budget burns unnecessarily. Plain depends_on guarantees start
+    # order, not health — the retry loop in server.ts still handles the
+    # boot race within workspace-service's own startup.
     depends_on:
       - nats
+      - workspace-service
+    restart: on-failure
     environment:
       NATS_URL: nats://nats:4222
       # Workspace-scoped: rows.json now lives at /clients/<slug>/rows.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,14 @@ services:
       NATS_URL: nats://nats:4222
       SESSION_STORE_PATH: /data/sessions.json
       PORT: "3001"
+      # Workspace registry — each child of /clients is a workspace, per
+      # [[Workspaces-as-Tenant-Primitive]]. ACTIVE_CLIENT_ID is optional;
+      # absent → first slug alphabetically (humain-vc today).
+      CLIENTS_ROOT: /clients
+      ACTIVE_CLIENT_ID: ${ACTIVE_CLIENT_ID:-}
     volumes:
       - workspace-data:/data
+      - ./clients:/clients:ro
 
   row-store:
     build: ./services/row-store

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -40,6 +40,7 @@ export type {
   UserContext,
   VariantFamily,
   VariantFamilySuggestion,
+  WorkspaceSummary,
 } from './types';
 export type { WorkspaceAdapter } from './adapter';
 export type { TransportConfig } from './transport';

--- a/packages/workspace/src/state.svelte.ts
+++ b/packages/workspace/src/state.svelte.ts
@@ -46,6 +46,21 @@ class AugmentItWorkspace {
    */
   workspaces: WorkspaceSummary[];
   active_client_id: string | null;
+  /**
+   * Surface for the switcher / debug panel. Lets the UI distinguish
+   * "we haven't tried yet" from "we tried and failed" from "no workspaces
+   * exist on disk", which were all visually identical when the only signal
+   * was workspaces.length === 0.
+   */
+  workspaces_status: 'idle' | 'loading' | 'ready' | 'error';
+  workspaces_error: string | null;
+  /**
+   * WebSocket connection status, mirrored from the transport's onStatus
+   * callback. Exposed so any surface (switcher, future status bar) can
+   * render visible feedback when the socket is down. Connect handlers in
+   * each remote forward into this.
+   */
+  connection_status: 'idle' | 'connecting' | 'open' | 'closed' | 'error';
 
   private transport: Transport | null = null;
   private lastSeenSeq = -1;
@@ -62,6 +77,9 @@ class AugmentItWorkspace {
     this.user = $state<UserContext | null>(null);
     this.last_capability = $state<string | null>(null);
     this.workspaces = $state<WorkspaceSummary[]>([]);
+    this.workspaces_status = $state<'idle' | 'loading' | 'ready' | 'error'>('idle');
+    this.workspaces_error = $state<string | null>(null);
+    this.connection_status = $state<'idle' | 'connecting' | 'open' | 'closed' | 'error'>('idle');
     // Read the persisted pick eagerly so the chat surface has a value to
     // forward on the very first turn. The server-side discovery
     // (workspace.list) reconciles it after mount.
@@ -93,23 +111,36 @@ class AugmentItWorkspace {
    * fallback). Returns the resolved active id.
    */
   async loadWorkspaces(): Promise<string | null> {
-    const result = (await this.invoke('workspace.list', {})) as {
-      workspaces: WorkspaceSummary[];
-      active_client_id: string | null;
-    };
-    this.workspaces = result.workspaces;
-    const persisted = this.active_client_id;
-    const persistedExists = persisted && result.workspaces.some((w) => w.client_id === persisted);
-    const resolved = persistedExists
-      ? persisted
-      : result.active_client_id ?? result.workspaces[0]?.client_id ?? null;
-    if (resolved !== persisted) {
-      // Tell the server about our pick so its process-wide fallback
-      // matches what the browser will send on chat turns.
-      if (resolved) await this.invoke('workspace.activate', { client_id: resolved });
-      this.setActiveClientId(resolved);
+    this.workspaces_status = 'loading';
+    this.workspaces_error = null;
+    try {
+      console.info('[workspace] loadWorkspaces → workspace.list');
+      const result = (await this.invoke('workspace.list', {})) as {
+        workspaces: WorkspaceSummary[];
+        active_client_id: string | null;
+      };
+      console.info('[workspace] workspace.list returned', result);
+      this.workspaces = result.workspaces;
+      const persisted = this.active_client_id;
+      const persistedExists = persisted && result.workspaces.some((w) => w.client_id === persisted);
+      const resolved = persistedExists
+        ? persisted
+        : result.active_client_id ?? result.workspaces[0]?.client_id ?? null;
+      if (resolved !== persisted) {
+        // Tell the server about our pick so its process-wide fallback
+        // matches what the browser will send on chat turns.
+        if (resolved) await this.invoke('workspace.activate', { client_id: resolved });
+        this.setActiveClientId(resolved);
+      }
+      this.workspaces_status = 'ready';
+      return resolved;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error('[workspace] loadWorkspaces failed', err);
+      this.workspaces_status = 'error';
+      this.workspaces_error = msg;
+      throw err;
     }
-    return resolved;
   }
 
   /**
@@ -143,8 +174,15 @@ class AugmentItWorkspace {
    */
   connect(config: Omit<TransportConfig, 'onFrame'>): void {
     if (this.transport) return;
+    console.info('[workspace] connect →', config.url);
+    const userOnStatus = config.onStatus;
     this.transport = createTransport({
       ...config,
+      onStatus: (s) => {
+        console.info('[workspace] transport status', s);
+        this.connection_status = s as typeof this.connection_status;
+        userOnStatus?.(s);
+      },
       onFrame: (frame) => this.handleFrame(frame),
     });
   }

--- a/packages/workspace/src/state.svelte.ts
+++ b/packages/workspace/src/state.svelte.ts
@@ -15,7 +15,14 @@
 // rule in https://svelte.dev/e/state_invalid_placement.
 
 import { createTransport, type ChatTurnReply, type ChatTurnRequest, type Transport, type TransportConfig } from './transport';
-import type { ActiveView, JobEvent, PromptTemplate, RecordSet, Row, ServerFrame, UserContext } from './types';
+import type { ActiveView, JobEvent, PromptTemplate, RecordSet, Row, ServerFrame, UserContext, WorkspaceSummary } from './types';
+
+// Where the browser stashes the operator's active workspace pick. Survives
+// reload; broadcast on change via the window event below so other remotes
+// (the chat, lenses) can react without re-reading localStorage. Per
+// [[Workspaces-as-Tenant-Primitive]] § "Active workspace, persisted".
+const ACTIVE_CLIENT_KEY = 'augment-it:active-client-id';
+export const WORKSPACE_CHANGED_EVENT = 'augment-it:workspace-changed';
 
 class AugmentItWorkspace {
   activeView: ActiveView;
@@ -31,6 +38,14 @@ class AugmentItWorkspace {
    * invoke() on every dispatch.
    */
   last_capability: string | null;
+  /**
+   * Workspace registry, populated by loadWorkspaces() on shell mount.
+   * Empty until then; the switcher reads from this and the chat surface
+   * reads active_client_id to forward into chat_turn context.
+   * Per [[Workspaces-as-Tenant-Primitive]].
+   */
+  workspaces: WorkspaceSummary[];
+  active_client_id: string | null;
 
   private transport: Transport | null = null;
   private lastSeenSeq = -1;
@@ -46,6 +61,78 @@ class AugmentItWorkspace {
     this.events = $state.raw<JobEvent[]>([]);
     this.user = $state<UserContext | null>(null);
     this.last_capability = $state<string | null>(null);
+    this.workspaces = $state<WorkspaceSummary[]>([]);
+    // Read the persisted pick eagerly so the chat surface has a value to
+    // forward on the very first turn. The server-side discovery
+    // (workspace.list) reconciles it after mount.
+    this.active_client_id = $state<string | null>(
+      typeof localStorage === 'undefined'
+        ? null
+        : localStorage.getItem(ACTIVE_CLIENT_KEY),
+    );
+
+    // Each federation remote loads its OWN workspace singleton (no shared
+    // block in the shell's rsbuild config — see shell/rsbuild.config.ts).
+    // Cross-instance coherence is by window event + localStorage. When the
+    // shell's switcher dispatches WORKSPACE_CHANGED_EVENT, every other
+    // remote's singleton updates its reactive state here.
+    if (typeof window !== 'undefined') {
+      window.addEventListener(WORKSPACE_CHANGED_EVENT, (ev: Event) => {
+        const detail = (ev as CustomEvent).detail as { client_id?: string } | undefined;
+        const next = detail?.client_id ?? null;
+        if (next !== this.active_client_id) this.active_client_id = next;
+      });
+    }
+  }
+
+  /**
+   * Fetch the workspace registry from the workspace-service, reconcile
+   * the persisted active pick against what actually exists on disk
+   * (gracefully falls back to the server's active if the persisted slug
+   * is gone — same shape as the Sort & Filter Lens archived-set
+   * fallback). Returns the resolved active id.
+   */
+  async loadWorkspaces(): Promise<string | null> {
+    const result = (await this.invoke('workspace.list', {})) as {
+      workspaces: WorkspaceSummary[];
+      active_client_id: string | null;
+    };
+    this.workspaces = result.workspaces;
+    const persisted = this.active_client_id;
+    const persistedExists = persisted && result.workspaces.some((w) => w.client_id === persisted);
+    const resolved = persistedExists
+      ? persisted
+      : result.active_client_id ?? result.workspaces[0]?.client_id ?? null;
+    if (resolved !== persisted) {
+      // Tell the server about our pick so its process-wide fallback
+      // matches what the browser will send on chat turns.
+      if (resolved) await this.invoke('workspace.activate', { client_id: resolved });
+      this.setActiveClientId(resolved);
+    }
+    return resolved;
+  }
+
+  /**
+   * Switch workspaces. Persists to localStorage, tells the server, and
+   * broadcasts a window event so other remotes (chat, lenses) can re-read
+   * their workspace-scoped state without polling.
+   */
+  async activateWorkspace(client_id: string): Promise<void> {
+    await this.invoke('workspace.activate', { client_id });
+    this.setActiveClientId(client_id);
+  }
+
+  private setActiveClientId(client_id: string | null): void {
+    this.active_client_id = client_id;
+    if (typeof localStorage !== 'undefined') {
+      if (client_id) localStorage.setItem(ACTIVE_CLIENT_KEY, client_id);
+      else localStorage.removeItem(ACTIVE_CLIENT_KEY);
+    }
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(
+        new CustomEvent(WORKSPACE_CHANGED_EVENT, { detail: { client_id } }),
+      );
+    }
   }
 
   /**

--- a/packages/workspace/src/state.svelte.ts
+++ b/packages/workspace/src/state.svelte.ts
@@ -154,10 +154,23 @@ class AugmentItWorkspace {
   }
 
   private setActiveClientId(client_id: string | null): void {
+    const prev = this.active_client_id;
     this.active_client_id = client_id;
     if (typeof localStorage !== 'undefined') {
       if (client_id) localStorage.setItem(ACTIVE_CLIENT_KEY, client_id);
       else localStorage.removeItem(ACTIVE_CLIENT_KEY);
+    }
+    // Clear tenant-scoped caches on a real switch (not initial set). Each
+    // remote re-fetches via its own record_set.list / row.list / etc. The
+    // server already has the new tenant's data file loaded by the time
+    // these refetches fire (row-store subscribes to workspace.active.changed
+    // and swaps synchronously).
+    if (prev && client_id && prev !== client_id) {
+      this.record_sets = {};
+      this.rows = {};
+      this.prompts = {};
+      this.events = [];
+      this.activeView = { kind: 'idle' };
     }
     if (typeof window !== 'undefined') {
       window.dispatchEvent(

--- a/packages/workspace/src/types.ts
+++ b/packages/workspace/src/types.ts
@@ -247,8 +247,22 @@ export type ChatTurnFrame = {
    * the active prompt draft id being discussed, etc. The server inlines
    * this into the user-message slab of the prompt so the model can act
    * on it without a separate fetch.
+   *
+   * `client_id` is the tenant boundary — the workspace the operator has
+   * toggled to in the shell header. Per [[Workspaces-as-Tenant-Primitive]]
+   * the wire field is `client_id` (lived-with naming with the prior
+   * substrate plan; the UI/spec word is "workspace").
    */
-  context?: { focused_prompt_id?: string; record_set_id?: string };
+  context?: { focused_prompt_id?: string; record_set_id?: string; client_id?: string };
+};
+
+// One workspace as discovered by the workspace-service. The directory
+// IS the workspace; display_name is title-cased from the slug.
+// See workspace.list / workspace.activate / workspace.active.
+export type WorkspaceSummary = {
+  client_id: string;
+  display_name: string;
+  has_env: boolean;
 };
 
 export type ChatResponseMode = 'answer' | 'propose' | 'invoke';

--- a/services/row-store/src/server.ts
+++ b/services/row-store/src/server.ts
@@ -60,23 +60,49 @@ async function migrateLegacyIfNeeded(active_client_id: string): Promise<void> {
   await copyFile(LEGACY_STORE_PATH, target);
 }
 
+/**
+ * Ask workspace-service which slug is currently active. Retries the
+ * request/reply because both services depend_on nats only — when the
+ * stack starts, row-store can race workspace-service's
+ * initWorkspaces + registerActiveQueryResponder by several seconds. A
+ * single-shot 5s request that previously fell back to a "default" slug
+ * was capturing reach-edu's migrated rows under the wrong tenant.
+ *
+ * Up to MAX_ATTEMPTS attempts of ~3s each → ~60s total budget. If the
+ * responder still hasn't come up, return null and let the caller crash
+ * the process so docker restarts us when workspace-service is finally
+ * ready. Never falls back to a synthetic "default" slug.
+ */
 async function queryActiveClientId(nc: NatsConnection): Promise<string | null> {
-  try {
-    const reply = await nc.request('workspace.active.requested', jc.encode({}), {
-      timeout: 5_000,
-    });
-    const decoded = jc.decode(reply.data) as { active_client_id: string | null };
-    return decoded.active_client_id;
-  } catch (err) {
-    console.warn(
-      JSON.stringify({
-        level: 'warn',
-        msg: 'workspace.active.requested failed; falling back to first client dir',
-        err: err instanceof Error ? err.message : String(err),
-      }),
-    );
-    return null;
+  const MAX_ATTEMPTS = 20;
+  const PER_ATTEMPT_TIMEOUT_MS = 3_000;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt += 1) {
+    try {
+      const reply = await nc.request('workspace.active.requested', jc.encode({}), {
+        timeout: PER_ATTEMPT_TIMEOUT_MS,
+      });
+      const decoded = jc.decode(reply.data) as { active_client_id: string | null };
+      if (decoded.active_client_id) return decoded.active_client_id;
+      // Responder is up but reports no active workspace yet — keep trying.
+      console.log(
+        JSON.stringify({
+          level: 'info',
+          msg: 'workspace-service responded with no active client_id; retrying',
+          attempt,
+        }),
+      );
+    } catch (err) {
+      console.log(
+        JSON.stringify({
+          level: 'info',
+          msg: 'workspace.active.requested not yet answered; retrying',
+          attempt,
+          err: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
   }
+  return null;
 }
 
 function subscribeToWorkspaceChanges(nc: NatsConnection): void {
@@ -101,11 +127,18 @@ async function main(): Promise<void> {
   const nc = await connect({ servers: NATS_URL, name: 'row-store-service' });
   console.log(JSON.stringify({ level: 'info', msg: 'nats connected', url: NATS_URL }));
 
-  const queried = await queryActiveClientId(nc);
-  // If the query failed and we have no signal at all, default the path
-  // to a sentinel under CLIENTS_ROOT. The first workspace switch will
-  // swap to the real tenant; until then capabilities serve empty.
-  const active_client_id = queried ?? 'default';
+  const active_client_id = await queryActiveClientId(nc);
+  // Without a real active workspace we have nothing useful to do — the
+  // earlier code defaulted to a synthetic "default" slug and silently
+  // trapped the legacy-migration into clients/default/rows.json. Crash
+  // instead; docker restart-policy will bring us back when workspace-
+  // service responds. Set `restart: unless-stopped` in compose if you
+  // want automatic recovery.
+  if (!active_client_id) {
+    throw new Error(
+      'row-store: workspace.active.requested unanswered after 20 attempts (~60s). workspace-service unreachable or has no workspaces. Refusing to boot under a synthetic default slug — that captures legacy data under the wrong tenant.',
+    );
+  }
   const initialPath = pathForClient(active_client_id);
   await migrateLegacyIfNeeded(active_client_id);
   await load(initialPath);

--- a/services/row-store/src/server.ts
+++ b/services/row-store/src/server.ts
@@ -1,16 +1,124 @@
-import { connect } from 'nats';
-import { load } from './store';
+// row-store-service — workspace-scoped record/row persistence.
+//
+// Per [[Workspaces-as-Tenant-Primitive]] the row-store JSON lives at
+// <CLIENTS_ROOT>/<client_id>/rows.json so the workspace is self-contained
+// on disk. On boot, the service asks workspace-service which slug is
+// active and loads that file; on workspace.active.changed it swaps to
+// the new tenant's file (after persisting any pending mutations to the
+// previous one).
+//
+// Migration: if the legacy /data/rows.json from pre-workspace-scoping
+// exists AND the initial active workspace doesn't yet have its own
+// rows.json, copy the legacy file in once so the operator doesn't lose
+// their existing record sets. One-shot, idempotent — runs only when
+// the target file doesn't exist.
+
+import { copyFile, mkdir, stat } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { connect, JSONCodec, type NatsConnection } from 'nats';
+import { load, swap } from './store';
 import { registerHandlers } from './handlers';
 
+const jc = JSONCodec();
+
 const NATS_URL = process.env.NATS_URL ?? 'nats://localhost:4222';
-const ROW_STORE_PATH = process.env.ROW_STORE_PATH ?? './data/rows.json';
+// /clients in docker, ../../clients for local dev. Same convention as
+// workspace-service.
+const CLIENTS_ROOT = resolve(process.env.CLIENTS_ROOT ?? '../../clients');
+// Legacy single-tenant path. Migrated into clients/<slug>/rows.json once
+// on first boot. Override or unset if no migration is needed.
+const LEGACY_STORE_PATH = process.env.LEGACY_ROW_STORE_PATH ?? '/data/rows.json';
+
+function pathForClient(client_id: string): string {
+  return join(CLIENTS_ROOT, client_id, 'rows.json');
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  return stat(path)
+    .then(() => true)
+    .catch(() => false);
+}
+
+/**
+ * One-shot migration: copy the legacy global rows.json into the active
+ * workspace's per-tenant file when the per-tenant file doesn't exist yet.
+ * Idempotent — subsequent boots find the per-tenant file and skip the copy.
+ */
+async function migrateLegacyIfNeeded(active_client_id: string): Promise<void> {
+  const target = pathForClient(active_client_id);
+  if (await fileExists(target)) return;
+  if (!(await fileExists(LEGACY_STORE_PATH))) return;
+  console.log(
+    JSON.stringify({
+      level: 'info',
+      msg: 'migrating legacy rows.json',
+      from: LEGACY_STORE_PATH,
+      to: target,
+    }),
+  );
+  await mkdir(dirname(target), { recursive: true });
+  await copyFile(LEGACY_STORE_PATH, target);
+}
+
+async function queryActiveClientId(nc: NatsConnection): Promise<string | null> {
+  try {
+    const reply = await nc.request('workspace.active.requested', jc.encode({}), {
+      timeout: 5_000,
+    });
+    const decoded = jc.decode(reply.data) as { active_client_id: string | null };
+    return decoded.active_client_id;
+  } catch (err) {
+    console.warn(
+      JSON.stringify({
+        level: 'warn',
+        msg: 'workspace.active.requested failed; falling back to first client dir',
+        err: err instanceof Error ? err.message : String(err),
+      }),
+    );
+    return null;
+  }
+}
+
+function subscribeToWorkspaceChanges(nc: NatsConnection): void {
+  (async () => {
+    const sub = nc.subscribe('workspace.active.changed');
+    for await (const msg of sub) {
+      try {
+        const { client_id } = jc.decode(msg.data) as { client_id: string; previous?: string };
+        const next = pathForClient(client_id);
+        console.log(JSON.stringify({ level: 'info', msg: 'workspace switch', to: client_id, path: next }));
+        await swap(next);
+      } catch (err) {
+        console.error('row-store: workspace.active.changed handler failed', err);
+      }
+    }
+  })().catch((err) => {
+    console.error('row-store: workspace.active.changed subscriber crashed', err);
+  });
+}
 
 async function main(): Promise<void> {
-  await load(ROW_STORE_PATH);
-  console.log(JSON.stringify({ level: 'info', msg: 'store loaded', path: ROW_STORE_PATH }));
-
   const nc = await connect({ servers: NATS_URL, name: 'row-store-service' });
   console.log(JSON.stringify({ level: 'info', msg: 'nats connected', url: NATS_URL }));
+
+  const queried = await queryActiveClientId(nc);
+  // If the query failed and we have no signal at all, default the path
+  // to a sentinel under CLIENTS_ROOT. The first workspace switch will
+  // swap to the real tenant; until then capabilities serve empty.
+  const active_client_id = queried ?? 'default';
+  const initialPath = pathForClient(active_client_id);
+  await migrateLegacyIfNeeded(active_client_id);
+  await load(initialPath);
+  console.log(
+    JSON.stringify({
+      level: 'info',
+      msg: 'store loaded',
+      client_id: active_client_id,
+      path: initialPath,
+    }),
+  );
+
+  subscribeToWorkspaceChanges(nc);
 
   registerHandlers(nc);
   console.log(JSON.stringify({ level: 'info', msg: 'row-store-service ready' }));

--- a/services/row-store/src/store.ts
+++ b/services/row-store/src/store.ts
@@ -134,6 +134,23 @@ export async function load(path: string): Promise<void> {
   }
 }
 
+/**
+ * Swap the active store file. Persists the current in-memory state to its
+ * existing path first (in case mutations were pending), then re-loads from
+ * the new path. Used when the operator toggles workspaces in the shell —
+ * see [[Workspaces-as-Tenant-Primitive]]. Idempotent: a swap to the
+ * current path is a no-op.
+ */
+export async function swap(newPath: string): Promise<void> {
+  if (newPath === storePath) return;
+  if (storePath) await persist();
+  await load(newPath);
+}
+
+export function getStorePath(): string {
+  return storePath;
+}
+
 async function persist(): Promise<void> {
   await writeFile(storePath, JSON.stringify(data, null, 2));
 }

--- a/services/workspace/src/capabilities.ts
+++ b/services/workspace/src/capabilities.ts
@@ -4,8 +4,33 @@
 
 import { JSONCodec } from 'nats';
 import { getNats } from './nats';
+import {
+  getActiveClientId,
+  listWorkspaces,
+  setActiveClientId,
+  type WorkspaceSummary,
+} from './workspaces';
 
 const jc = JSONCodec();
+
+// workspace.* capabilities are served locally by the workspace-service —
+// no NATS round-trip, no domain microservice owns them. The shape mirrors
+// the NATS-dispatched path so the browser sees one uniform invoke surface.
+// See [[Workspaces-as-Tenant-Primitive]] § "Toggle UI" + "Tenant-aware
+// envelope".
+const LOCAL_CAPABILITIES: Record<string, (args: unknown) => Promise<unknown>> = {
+  'workspace.list': async () => {
+    const workspaces = await listWorkspaces();
+    return { workspaces, active_client_id: getActiveClientId() };
+  },
+  'workspace.activate': async (args: unknown) => {
+    const a = (args ?? {}) as { client_id?: string };
+    if (!a.client_id) throw new Error('workspace.activate requires { client_id }');
+    const summary: WorkspaceSummary = setActiveClientId(a.client_id);
+    return { active: summary };
+  },
+  'workspace.active': async () => ({ active_client_id: getActiveClientId() }),
+};
 
 const CAPABILITY_TO_SUBJECT: Record<string, string> = {
   // record set operations
@@ -161,6 +186,8 @@ const CAPABILITY_TIMEOUTS_MS: Record<string, number> = {
 };
 
 export async function dispatch(capability: string, args: unknown): Promise<unknown> {
+  const local = LOCAL_CAPABILITIES[capability];
+  if (local) return local(args);
   const subject = CAPABILITY_TO_SUBJECT[capability];
   if (!subject) throw new Error(`unknown capability: ${capability}`);
   const timeout = CAPABILITY_TIMEOUTS_MS[capability] ?? 5_000;

--- a/services/workspace/src/chat.ts
+++ b/services/workspace/src/chat.ts
@@ -15,6 +15,7 @@
 
 import { JSONCodec } from 'nats';
 import { getNats } from './nats';
+import { getActiveClientId } from './workspaces';
 
 const jc = JSONCodec();
 
@@ -147,7 +148,7 @@ export const CHAT_TOOLS = [
 export type ChatTurnInput = {
   message: string;
   thread?: { role: 'user' | 'assistant'; content: string }[];
-  context?: { focused_prompt_id?: string; record_set_id?: string };
+  context?: { focused_prompt_id?: string; record_set_id?: string; client_id?: string };
   suggestions?: { capability: string; hint: string }[];
 };
 
@@ -175,10 +176,17 @@ function suggestedVerbsSlab(suggestions?: { capability: string; hint: string }[]
 
 function contextSlab(ctx?: ChatTurnInput['context']): string {
   const parts: string[] = [];
-  // Active client — v0.0.1 hardcodes reach-edu (the only client today).
-  // The architecture spec (Chat-Context-Awareness-Architecture) will replace
-  // this with a workspace-resolved active_client_id once a second client lands.
-  parts.push(`The active client is: reach-edu (this is the client_id arg for corpus.inbox.add and any other client-scoped capability).`);
+  // Active workspace — resolved from the browser's persisted choice
+  // (sent on every chat_turn) with the server's process-wide active
+  // slug as a fallback. Per [[Workspaces-as-Tenant-Primitive]] § "Per-
+  // workspace .env pickup". Null means no workspaces exist on disk —
+  // the model should refuse client-scoped capabilities in that case.
+  const active = ctx?.client_id ?? getActiveClientId();
+  if (active) {
+    parts.push(`The active client is: ${active} (this is the client_id arg for corpus.inbox.add and any other client-scoped capability).`);
+  } else {
+    parts.push(`No workspace is active. Refuse client-scoped capabilities and ask the user to pick a workspace from the header switcher.`);
+  }
   if (ctx?.focused_prompt_id) parts.push(`The user is currently looking at prompt: ${ctx.focused_prompt_id}`);
   if (ctx?.record_set_id) parts.push(`The user is currently in record set: ${ctx.record_set_id}`);
   return parts.join('\n') + '\n';

--- a/services/workspace/src/server.ts
+++ b/services/workspace/src/server.ts
@@ -3,7 +3,7 @@ import websocket from '@fastify/websocket';
 import { connectNats } from './nats';
 import { loadSessions } from './auth';
 import { registerWebsocket } from './ws';
-import { initWorkspaces } from './workspaces';
+import { initWorkspaces, registerActiveQueryResponder } from './workspaces';
 
 const NATS_URL = process.env.NATS_URL ?? 'nats://localhost:4222';
 const SESSION_STORE_PATH = process.env.SESSION_STORE_PATH ?? './data/sessions.json';
@@ -30,6 +30,9 @@ async function main(): Promise<void> {
 
   await connectNats(NATS_URL);
   app.log.info({ url: NATS_URL }, 'nats connected');
+
+  registerActiveQueryResponder();
+  app.log.info('workspace.active.requested responder registered');
 
   await registerWebsocket(app);
 

--- a/services/workspace/src/server.ts
+++ b/services/workspace/src/server.ts
@@ -3,9 +3,14 @@ import websocket from '@fastify/websocket';
 import { connectNats } from './nats';
 import { loadSessions } from './auth';
 import { registerWebsocket } from './ws';
+import { initWorkspaces } from './workspaces';
 
 const NATS_URL = process.env.NATS_URL ?? 'nats://localhost:4222';
 const SESSION_STORE_PATH = process.env.SESSION_STORE_PATH ?? './data/sessions.json';
+// Where to look for workspace directories. /clients in docker, repo-relative
+// for local dev. Each child dir == one workspace; see workspaces.ts.
+const CLIENTS_ROOT = process.env.CLIENTS_ROOT ?? '../../clients';
+const INITIAL_ACTIVE_CLIENT_ID = process.env.ACTIVE_CLIENT_ID;
 const PORT = Number(process.env.PORT ?? 3001);
 
 async function main(): Promise<void> {
@@ -16,6 +21,12 @@ async function main(): Promise<void> {
 
   await loadSessions(SESSION_STORE_PATH);
   app.log.info({ path: SESSION_STORE_PATH }, 'sessions loaded');
+
+  await initWorkspaces({
+    clients_root: CLIENTS_ROOT,
+    initial_active_id: INITIAL_ACTIVE_CLIENT_ID,
+  });
+  app.log.info({ clients_root: CLIENTS_ROOT }, 'workspaces initialized');
 
   await connectNats(NATS_URL);
   app.log.info({ url: NATS_URL }, 'nats connected');

--- a/services/workspace/src/workspaces.ts
+++ b/services/workspace/src/workspaces.ts
@@ -1,0 +1,168 @@
+// Workspaces — the tenant primitive (per [[Workspaces-as-Tenant-Primitive]]).
+//
+// Source of truth at baby step 1: the filesystem. Each immediate child of
+// CLIENTS_ROOT is a workspace; the directory IS the workspace. No manifest,
+// no DB. Display name is title-cased from the slug.
+//
+// Per-workspace .env: loaded into a frozen, in-memory map keyed by slug.
+// Do NOT merge into process.env — `WorkspaceService` runs in one process
+// and serves all workspaces; merging would bleed env across tenants the
+// moment two are active in the same session, or even just touched in
+// sequence by a domain service that reads from process.env at dispatch
+// time. The connector-config seam will resolve typed connector configs
+// (LLM / search / CRM / MCP / storage) from this map in a later step;
+// step 1 just exposes the raw env to authorized callers.
+//
+// Active workspace: tracked in memory per process (baby step 1). The
+// browser persists the chosen slug in localStorage and sends it on every
+// chat turn; the server reads ctx.client_id at chat dispatch time. The
+// process-wide active value is a fallback for capabilities that fire
+// without an explicit client_id arg, and a hook the audit log can read
+// in a later step. Persistence to a JSON file is intentionally deferred
+// — multi-user / per-session active workspace is a later spec move.
+
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+export type WorkspaceSummary = {
+  client_id: string;
+  display_name: string;
+  has_env: boolean;
+};
+
+export type WorkspaceConfig = {
+  client_id: string;
+  /** Frozen view of clients/<slug>/.env. Empty object if no .env present. */
+  env: Readonly<Record<string, string>>;
+};
+
+let CLIENTS_ROOT = '';
+const configs = new Map<string, WorkspaceConfig>();
+let activeClientId: string | null = null;
+
+function titleCase(slug: string): string {
+  return slug
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+/**
+ * Minimal .env parser. Handles KEY=value lines, # comments, blank lines,
+ * and single- or double-quoted values. Does NOT handle expansion (${FOO})
+ * — workspace .env files are tenant-scoped, not layered, so expansion
+ * would only cause surprise. Bring in dotenv if and when a real need
+ * shows up.
+ */
+function parseEnv(raw: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq < 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    if (!key) continue;
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+async function loadConfigFor(client_id: string): Promise<WorkspaceConfig> {
+  const envPath = join(CLIENTS_ROOT, client_id, '.env');
+  let env: Record<string, string> = {};
+  try {
+    const raw = await readFile(envPath, 'utf8');
+    env = parseEnv(raw);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+  return { client_id, env: Object.freeze(env) };
+}
+
+/**
+ * Initialize the workspace registry. Scans CLIENTS_ROOT for directories,
+ * primes each one's WorkspaceConfig, and resolves an initial active slug.
+ * Active selection precedence: explicit ACTIVE_CLIENT_ID env > alphabetical
+ * first discovered > null.
+ */
+export async function initWorkspaces(opts: {
+  clients_root: string;
+  initial_active_id?: string;
+}): Promise<void> {
+  CLIENTS_ROOT = resolve(opts.clients_root);
+  configs.clear();
+  const slugs = await discover();
+  for (const slug of slugs) {
+    configs.set(slug, await loadConfigFor(slug));
+  }
+  if (opts.initial_active_id && configs.has(opts.initial_active_id)) {
+    activeClientId = opts.initial_active_id;
+  } else {
+    activeClientId = slugs[0] ?? null;
+  }
+}
+
+async function discover(): Promise<string[]> {
+  let entries: string[] = [];
+  try {
+    entries = await readdir(CLIENTS_ROOT);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+  const slugs: string[] = [];
+  for (const name of entries) {
+    if (name.startsWith('.')) continue;
+    const s = await stat(join(CLIENTS_ROOT, name)).catch(() => null);
+    if (s && s.isDirectory()) slugs.push(name);
+  }
+  return slugs.sort();
+}
+
+export async function listWorkspaces(): Promise<WorkspaceSummary[]> {
+  const slugs = await discover();
+  // Re-prime configs for newly added dirs so a fresh `mkdir clients/foo`
+  // is picked up without a server restart.
+  for (const slug of slugs) {
+    if (!configs.has(slug)) configs.set(slug, await loadConfigFor(slug));
+  }
+  return slugs.map((client_id) => ({
+    client_id,
+    display_name: titleCase(client_id),
+    has_env: (configs.get(client_id)?.env && Object.keys(configs.get(client_id)!.env).length > 0) || false,
+  }));
+}
+
+export function getActiveClientId(): string | null {
+  return activeClientId;
+}
+
+export function setActiveClientId(client_id: string): WorkspaceSummary {
+  if (!configs.has(client_id)) {
+    throw new Error(`unknown workspace: ${client_id}`);
+  }
+  activeClientId = client_id;
+  return {
+    client_id,
+    display_name: titleCase(client_id),
+    has_env: Object.keys(configs.get(client_id)!.env).length > 0,
+  };
+}
+
+/**
+ * Return the resolved env for a workspace. Returns null when the slug is
+ * unknown — callers decide whether that's a refusal or a quiet skip.
+ */
+export function getWorkspaceEnv(client_id: string): Readonly<Record<string, string>> | null {
+  const cfg = configs.get(client_id);
+  return cfg ? cfg.env : null;
+}

--- a/services/workspace/src/workspaces.ts
+++ b/services/workspace/src/workspaces.ts
@@ -23,6 +23,19 @@
 
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
+import { JSONCodec } from 'nats';
+import { getNats } from './nats';
+
+const jc = JSONCodec();
+
+// Subject for cross-service workspace-switch broadcast. Domain services
+// (row-store, prompt-store, response-store, content-ingest) subscribe and
+// re-scope their state when the operator toggles workspaces. Also added to
+// the browser-broadcast list in ws.ts so other tabs / remotes stay in sync.
+export const WORKSPACE_ACTIVE_CHANGED_SUBJECT = 'workspace.active.changed';
+// One-shot request a domain service can fire on boot to discover the
+// currently-active workspace before subscribing to changes.
+export const WORKSPACE_ACTIVE_REQUESTED_SUBJECT = 'workspace.active.requested';
 
 export type WorkspaceSummary = {
   client_id: string;
@@ -111,6 +124,25 @@ export async function initWorkspaces(opts: {
   }
 }
 
+/**
+ * Domain services (row-store, etc.) ask "who's active right now" via NATS
+ * request/reply on workspace.active.requested. Subscribed once at boot
+ * after NATS is connected.
+ */
+export function registerActiveQueryResponder(): void {
+  const nc = getNats();
+  (async () => {
+    const sub = nc.subscribe(WORKSPACE_ACTIVE_REQUESTED_SUBJECT);
+    for await (const msg of sub) {
+      if (msg.reply) {
+        msg.respond(jc.encode({ active_client_id: activeClientId }));
+      }
+    }
+  })().catch((err) => {
+    console.error('[workspaces] active-query subscriber crashed', err);
+  });
+}
+
 async function discover(): Promise<string[]> {
   let entries: string[] = [];
   try {
@@ -150,7 +182,21 @@ export function setActiveClientId(client_id: string): WorkspaceSummary {
   if (!configs.has(client_id)) {
     throw new Error(`unknown workspace: ${client_id}`);
   }
+  const prev = activeClientId;
   activeClientId = client_id;
+  // Broadcast the switch so domain services (row-store today; prompt-store
+  // / response-store / content-ingest next) can re-scope their state to
+  // the new tenant. Fire-and-forget — publish is local to NATS.
+  if (prev !== client_id) {
+    try {
+      getNats().publish(
+        WORKSPACE_ACTIVE_CHANGED_SUBJECT,
+        jc.encode({ client_id, previous: prev }),
+      );
+    } catch (err) {
+      console.warn('[workspaces] could not publish workspace.active.changed', err);
+    }
+  }
   return {
     client_id,
     display_name: titleCase(client_id),

--- a/services/workspace/src/ws.ts
+++ b/services/workspace/src/ws.ts
@@ -34,6 +34,11 @@ const BROADCAST_SUBJECTS = [
   'response.flagged',
   'response.deleted',
   'response.edited',
+  // Workspace switch — emitted by workspace-service when the operator
+  // toggles workspaces. Browsers receive the event and clear their cached
+  // record_sets / rows so remotes refetch against the new tenant. See
+  // [[Workspaces-as-Tenant-Primitive]] § "Tenant-aware envelope".
+  'workspace.active.changed',
 ];
 
 type Session = {

--- a/services/workspace/src/ws.ts
+++ b/services/workspace/src/ws.ts
@@ -101,7 +101,7 @@ export async function registerWebsocket(app: FastifyInstance): Promise<void> {
         args?: unknown;
         message?: string;
         thread_id?: string;
-        context?: { focused_prompt_id?: string; record_set_id?: string };
+        context?: { focused_prompt_id?: string; record_set_id?: string; client_id?: string };
         thread?: { role: 'user' | 'assistant'; content: string }[];
         suggestions?: { capability: string; hint: string }[];
       };

--- a/shell/src/App.svelte
+++ b/shell/src/App.svelte
@@ -3,7 +3,9 @@
   import ModeToggle from './ModeToggle.svelte';
   import MountHost from './MountHost.svelte';
   import FlowWidget from './FlowWidget.svelte';
+  import WorkspaceSwitcher from './WorkspaceSwitcher.svelte';
   import ToggleHeader from '@augment-it/shared-ui/ToggleHeader__PromptOrPackage--Icons.svelte';
+  import { workspace } from '@augment-it/workspace';
   import {
     ROTATION,
     PAIRINGS,
@@ -236,6 +238,32 @@
     return () => window.removeEventListener('augment-it:enrich-record', onEnrich);
   });
 
+  // ---- workspace bootstrap -----------------------------------------------
+  // Discover workspaces from the workspace-service on mount, reconcile the
+  // browser's persisted active pick against what's on disk. The transport
+  // is already connected by the time the shell renders (see remotes init);
+  // a tiny retry covers the rare race where workspace.list fires before
+  // the WS session frame.
+  onMount(() => {
+    let cancelled = false;
+    const tryLoad = async (attempt = 0): Promise<void> => {
+      if (cancelled) return;
+      try {
+        await workspace.loadWorkspaces();
+      } catch (err) {
+        if (attempt < 5) {
+          setTimeout(() => tryLoad(attempt + 1), 200 * (attempt + 1));
+        } else {
+          console.warn('[shell] workspace.list failed; switcher will be empty', err);
+        }
+      }
+    };
+    void tryLoad();
+    return () => {
+      cancelled = true;
+    };
+  });
+
   // ---- cross-remote navigation (dispatched by any remote) -----------------
   // Remotes that want to send the user to a different surface dispatch a
   // window event:  window.dispatchEvent(new CustomEvent('augment-it:navigate',
@@ -397,6 +425,7 @@
     </button>
     <span class="muted">tiling host · :3100</span>
     <ModeToggle />
+    <WorkspaceSwitcher />
   </div>
 </header>
 

--- a/shell/src/App.svelte
+++ b/shell/src/App.svelte
@@ -239,19 +239,32 @@
   });
 
   // ---- workspace bootstrap -----------------------------------------------
-  // Discover workspaces from the workspace-service on mount, reconcile the
-  // browser's persisted active pick against what's on disk. The transport
-  // is already connected by the time the shell renders (see remotes init);
-  // a tiny retry covers the rare race where workspace.list fires before
-  // the WS session frame.
+  // The shell now makes its own capability calls (workspace.list / .activate
+  // from the header switcher), so its singleton needs its OWN transport.
+  // Each federation remote also connects, but those instances are separate
+  // — no `shared` block in rsbuild config — and pre-today the shell didn't
+  // dispatch anything itself.
+  //
+  // Connect first, then load workspaces. `workspace.connect()` is idempotent
+  // on the singleton, so if a remote raced us and connected first the
+  // second call is a no-op.
   onMount(() => {
+    const TOKEN_KEY = 'augment_it_session_token';
+    workspace.connect({
+      url: 'ws://localhost:3001/ws',
+      getToken: () => localStorage.getItem(TOKEN_KEY),
+      saveToken: (t) => localStorage.setItem(TOKEN_KEY, t),
+      onStatus: () => {
+        /* shell doesn't render its own connection indicator — the chat rail does */
+      },
+    });
     let cancelled = false;
     const tryLoad = async (attempt = 0): Promise<void> => {
       if (cancelled) return;
       try {
         await workspace.loadWorkspaces();
       } catch (err) {
-        if (attempt < 5) {
+        if (attempt < 8) {
           setTimeout(() => tryLoad(attempt + 1), 200 * (attempt + 1));
         } else {
           console.warn('[shell] workspace.list failed; switcher will be empty', err);

--- a/shell/src/WorkspaceSwitcher.svelte
+++ b/shell/src/WorkspaceSwitcher.svelte
@@ -1,0 +1,221 @@
+<script lang="ts">
+  // Workspace switcher — top-right header chrome.
+  //
+  // Reads workspace.workspaces (populated by workspace.list) and the
+  // operator's active pick from the singleton; clicking a row activates
+  // that workspace via workspace.activateWorkspace(), which persists to
+  // localStorage and broadcasts WORKSPACE_CHANGED_EVENT.
+  //
+  // Per [[Workspaces-as-Tenant-Primitive]] § "Toggle UI": every workspace
+  // is the boundary; the directory IS the workspace; no creation UI here
+  // (operator does `mkdir clients/<slug>/` on disk, picks up on next
+  // refresh).
+
+  import { workspace } from '@augment-it/workspace';
+
+  let open = $state<boolean>(false);
+  let switching = $state<boolean>(false);
+  let menuEl = $state<HTMLDivElement | undefined>(undefined);
+
+  const active = $derived(
+    workspace.workspaces.find((w) => w.client_id === workspace.active_client_id),
+  );
+  const label = $derived(active?.display_name ?? workspace.active_client_id ?? 'no workspace');
+  const empty = $derived(workspace.workspaces.length === 0);
+
+  function toggle(): void {
+    if (empty) return;
+    open = !open;
+  }
+
+  async function pick(client_id: string): Promise<void> {
+    if (client_id === workspace.active_client_id) {
+      open = false;
+      return;
+    }
+    switching = true;
+    try {
+      await workspace.activateWorkspace(client_id);
+    } finally {
+      switching = false;
+      open = false;
+    }
+  }
+
+  function onDocPointer(ev: PointerEvent): void {
+    if (!open) return;
+    if (menuEl && !menuEl.contains(ev.target as Node)) open = false;
+  }
+
+  function onKey(ev: KeyboardEvent): void {
+    if (ev.key === 'Escape' && open) open = false;
+  }
+
+  $effect(() => {
+    document.addEventListener('pointerdown', onDocPointer);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('pointerdown', onDocPointer);
+      document.removeEventListener('keydown', onKey);
+    };
+  });
+</script>
+
+<div class="workspace-switcher" bind:this={menuEl}>
+  <button
+    type="button"
+    class="trigger"
+    class:open
+    class:empty
+    aria-haspopup="listbox"
+    aria-expanded={open}
+    disabled={empty || switching}
+    title={empty ? 'no workspaces — add a directory under clients/' : `switch workspace (active: ${label})`}
+    onclick={toggle}
+  >
+    <span class="dot" aria-hidden="true"></span>
+    <span class="label">{label}</span>
+    <span class="chev" aria-hidden="true">{open ? '▴' : '▾'}</span>
+  </button>
+
+  {#if open}
+    <ul class="menu" role="listbox" aria-label="Workspaces">
+      {#each workspace.workspaces as w (w.client_id)}
+        {@const isActive = w.client_id === workspace.active_client_id}
+        <li>
+          <button
+            type="button"
+            class="row"
+            class:active={isActive}
+            role="option"
+            aria-selected={isActive}
+            onclick={() => pick(w.client_id)}
+          >
+            <span class="row-label">{w.display_name}</span>
+            <span class="row-slug">{w.client_id}</span>
+            {#if w.has_env}
+              <span class="env-chip" title="per-workspace .env present">env</span>
+            {/if}
+            {#if isActive}
+              <span class="check" aria-hidden="true">✓</span>
+            {/if}
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .workspace-switcher {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+  }
+  .trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: transparent;
+    color: var(--color-text);
+    border: 1px solid var(--color-border);
+    padding: 4px 10px;
+    border-radius: 4px;
+    font: inherit;
+    font-size: 11px;
+    cursor: pointer;
+    transition: all 0.12s ease;
+  }
+  .trigger:hover:not(:disabled) {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+  }
+  .trigger.open {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+    background: var(--color-selected-tint);
+  }
+  .trigger.empty,
+  .trigger:disabled {
+    color: var(--color-text-muted);
+    cursor: not-allowed;
+  }
+  .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    flex-shrink: 0;
+  }
+  .trigger.empty .dot { background: var(--color-text-muted); }
+  .label {
+    font-weight: 500;
+    letter-spacing: 0.02em;
+  }
+  .chev {
+    color: var(--color-text-muted);
+    font-size: 10px;
+  }
+
+  .menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 200;
+    margin: 0;
+    padding: 4px;
+    list-style: none;
+    background: var(--color-surface-raised);
+    border: 1px solid var(--color-border);
+    border-radius: 6px;
+    box-shadow: var(--fx-card-shadow);
+    min-width: 220px;
+    max-height: 60vh;
+    overflow: auto;
+  }
+  .row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    background: transparent;
+    color: var(--color-text);
+    border: 0;
+    padding: 6px 10px;
+    border-radius: 4px;
+    font: inherit;
+    font-size: 12px;
+    text-align: left;
+    cursor: pointer;
+  }
+  .row:hover { background: var(--color-selected-tint); }
+  .row.active {
+    background: var(--color-selected-tint);
+    color: var(--color-accent);
+  }
+  .row-label {
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .row-slug {
+    color: var(--color-text-muted);
+    font-size: 10px;
+    font-family: var(--font-mono, monospace);
+  }
+  .env-chip {
+    font-size: 9px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--color-text-muted);
+    border: 1px solid var(--color-border);
+    border-radius: 3px;
+    padding: 1px 4px;
+  }
+  .check {
+    color: var(--color-accent);
+    font-size: 11px;
+  }
+</style>

--- a/shell/src/WorkspaceSwitcher.svelte
+++ b/shell/src/WorkspaceSwitcher.svelte
@@ -20,8 +20,30 @@
   const active = $derived(
     workspace.workspaces.find((w) => w.client_id === workspace.active_client_id),
   );
-  const label = $derived(active?.display_name ?? workspace.active_client_id ?? 'no workspace');
   const empty = $derived(workspace.workspaces.length === 0);
+  // Visible state — never just "empty + disabled". The pill tells the user
+  // why: are we still waiting on the socket, did the call fail, is the
+  // server truly returning zero workspaces?
+  const label = $derived.by(() => {
+    if (workspace.connection_status === 'connecting' || workspace.connection_status === 'idle') return 'connecting…';
+    if (workspace.workspaces_status === 'loading') return 'loading…';
+    if (workspace.workspaces_status === 'error') return 'error · hover';
+    if (active) return active.display_name;
+    if (workspace.active_client_id) return workspace.active_client_id;
+    return 'no workspaces';
+  });
+  const tooltip = $derived.by(() => {
+    if (workspace.connection_status === 'closed' || workspace.connection_status === 'error') {
+      return `WebSocket ${workspace.connection_status} — workspace-service at ws://localhost:3001/ws unreachable`;
+    }
+    if (workspace.workspaces_status === 'error' && workspace.workspaces_error) {
+      return `workspace.list failed: ${workspace.workspaces_error}`;
+    }
+    if (empty && workspace.workspaces_status === 'ready') {
+      return 'no directories under clients/ — workspace-service returned an empty list';
+    }
+    return `switch workspace (active: ${label})`;
+  });
 
   function toggle(): void {
     if (empty) return;
@@ -70,7 +92,7 @@
     aria-haspopup="listbox"
     aria-expanded={open}
     disabled={empty || switching}
-    title={empty ? 'no workspaces — add a directory under clients/' : `switch workspace (active: ${label})`}
+    title={tooltip}
     onclick={toggle}
   >
     <span class="dot" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary

Workspaces become the tenant primitive across augment-it: the operator picks one in the shell's top-right switcher, and every microservice scopes its work to that workspace. The directory under `clients/<slug>/` IS the workspace — no manifest, no DB. Inspired by [[Cloud-Variant-of-Dididecks-AI-Workspace]] but filesystem-backed for local dev; the typed `ConnectorRegistry` (LLM / search / CRM / MCP / storage) the spec calls for lands in step 2.

### Five commits

- `a31759d` **`submodule(clients/humain-vc)`** — add as private submodule pointing at `lossless-group/humain-vc-data`. Mirrors the `clients/reach-edu` pattern.
- `86e75a9` **`feat(...)`** — the headline. Tenant primitive shipped end-to-end: switcher UI, `workspace.list / .activate / .active` capabilities served locally by workspace-service (no NATS round-trip), per-workspace `.env` loaded into a frozen scoped map (NOT merged into `process.env`), chat slab reads `ctx.client_id`, hardcoded `reach-edu` retires. Spec at `context-v/specs/Workspaces-as-Tenant-Primitive.md` (v0.0.0.1, Draft).
- `281bf55` **`progress(workspaces)`** — visibility additions. Shell connects its own workspace singleton; switcher pill renders real state (`connecting…` / `loading…` / `error · hover` / `no workspaces` / active name); `workspaces_status`, `workspaces_error`, `connection_status` reactive state; `console.info`/`console.error` narrate the connect → list flow.
- `495293a` **`progress(workspaces, row-store)`** — row-store becomes the first workspace-scoped domain service. Reads from `<CLIENTS_ROOT>/<client_id>/rows.json`, subscribes to `workspace.active.changed` on NATS, swaps file on toggle. Legacy `/data/rows.json` migrates into the active tenant on first boot (idempotent, one-shot). Browser singleton clears cached `record_sets` + `rows` + `prompts` + `events` on switch; record-collector and sort-filter-lens listen for `augment-it:workspace-changed` and refetch.
- `6fe4d48` **`fix(workspaces, row-store, clients/humain-vc)`** — race fix. `workspace.active.requested` now retries up to ~60s before throwing; refuses to boot under a synthetic `default` slug. Caught a real bug: the first migration landed under `clients/default/rows.json` because row-store raced workspace-service's NATS subscriber. Docker-compose: `depends_on: workspace-service`, `restart: on-failure`. humain-vc's `.gitignore` now ignores `rows.json` + `.DS_Store`.

### Design choices, named

- **Wire field stays `client_id`.** Lived-with naming collision: the prior `Augment-It-Workspace-Walking-Skeleton` plan's "Workspace Service" is the substrate; this spec's "workspace" is the tenant. Disambiguated in prose at the top of `Workspaces-as-Tenant-Primitive.md`, not by renaming.
- **`.env` scoped per workspace, NOT merged into `process.env`.** workspace-service runs in one process and serves all tenants; merging would bleed Decile credentials from humain-vc into a reach-edu chat turn the moment any downstream service reads from `process.env` at dispatch time.
- **Per-tenant data file at `clients/<slug>/rows.json`** (not `data/<slug>/`). Picks "stored at the client directory level" from the spec's open question — workspace becomes self-contained on disk, export and termination trivial.
- **Each federation remote has its own workspace singleton.** No `shared` block in rsbuild config (existing constraint). Cross-instance state sync via `augment-it:workspace-changed` window event + localStorage; constructor-wired listener in `state.svelte.ts`.

### What's still loose

- Other stores (prompt-store, response-store, content-ingest) still serve globally. Prompts being cross-tenant is plausibly desirable; responses almost certainly should be tenant-scoped.
- `workspace_slug` on every NATS envelope is still arg-by-arg.
- `clients/reach-edu/rows.json` needs the same `.gitignore` treatment in that submodule — left for the operator (it's the operator's submodule cadence).
- Per-workspace branded theme, RBAC, audit log, registration flow, cross-app workspace sync — all named in the spec's "Terminal vision" section as explicit later moves.

## Test plan

- [ ] `pnpm stack down && pnpm stack up`; verify row-store logs INFO retries while workspace-service boots, then `store loaded { client_id, path }`.
- [ ] Refresh `localhost:3100`; switcher in top-right shows active workspace name (Humain Vc or Reach Edu).
- [ ] Toggle to Reach Edu — record-collector populates with existing record sets (Master Pipeline Tracker, RSVP List).
- [ ] Toggle to Humain Vc — record-collector empty; upload a CSV; record set appears scoped to humain-vc.
- [ ] Toggle back to Reach Edu — original data still there, humain-vc upload absent.
- [ ] Verify per-tenant disk state: `ls clients/humain-vc/rows.json clients/reach-edu/rows.json` both exist; no `clients/default/`.
- [ ] Verify `/inbox <url>` chat verb lands the URL under the active tenant's corpus dir.
- [ ] Browser DevTools console shows `[workspace] connect → ws://localhost:3001/ws` → `transport status open` → `workspace.list returned { workspaces: [2], … }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)