### PR TITLE
Augment from Affiliations — MVP shipped, rate/link/enrich in one screen

### DIFF
--- a/apps/affiliation-rating-resolver/package.json
+++ b/apps/affiliation-rating-resolver/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@augment-it/affiliation-rating-resolver",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "rsbuild dev",
+    "build": "rsbuild build",
+    "preview": "rsbuild preview",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "dependencies": {
+    "@augment-it/theme": "workspace:*",
+    "@augment-it/workspace": "workspace:*",
+    "svelte": "^5.56.4"
+  },
+  "devDependencies": {
+    "@module-federation/enhanced": "^2.6.0",
+    "@module-federation/rsbuild-plugin": "^2.6.0",
+    "@rsbuild/core": "^2.1.2",
+    "@rsbuild/plugin-svelte": "^2.0.0",
+    "svelte-check": "^4.7.1",
+    "typescript": "^6.0.3"
+  }
+}

--- a/apps/affiliation-rating-resolver/rsbuild.config.ts
+++ b/apps/affiliation-rating-resolver/rsbuild.config.ts
@@ -1,0 +1,47 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginSvelte } from '@rsbuild/plugin-svelte';
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
+
+// Federated remote — affiliation-rating-resolver. The write half of the
+// Augment-from-Affiliations CSV round-trip: reimport a rating-edited CSV
+// (uploaded through the existing Record Collector path), map columns once,
+// then write relevance/relevance_note onto each row's `affiliations` edge
+// via the affiliation.rate capability. No match/create — every row's
+// person + org already exist in canonical; this only resolves the LOOKUP
+// key (person_uuid, org_slug) and writes the rating. See
+// context-v/specs/Augment-From-Affiliations.md.
+export default defineConfig({
+  plugins: [
+    pluginSvelte(),
+    pluginModuleFederation({
+      name: 'affiliationRatingResolver',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './mount': './src/mount.ts',
+      },
+      dts: false,
+    }),
+  ],
+  source: {
+    entry: { index: './src/index.ts' },
+  },
+  output: {
+    target: 'web',
+    overrideBrowserslist: ['last 2 Chrome versions', 'last 2 Firefox versions', 'last 2 Safari versions'],
+  },
+  tools: {
+    swc: {
+      jsc: { target: 'es2022' },
+    },
+  },
+  html: {
+    title: 'augment-it · affiliation-rating-resolver',
+  },
+  server: {
+    port: 3012,
+    cors: { origin: ['http://localhost:3100'] }, // the federation shell
+  },
+  dev: {
+    assetPrefix: 'http://localhost:3012',
+  },
+});

--- a/apps/affiliation-rating-resolver/src/App.svelte
+++ b/apps/affiliation-rating-resolver/src/App.svelte
@@ -472,8 +472,8 @@
             <label class="arr-label" for="arr-relevance">relevance</label>
             <select id="arr-relevance" bind:value={relevanceInput}>
               <option value="">— not rated —</option>
-              {#each RELEVANCE_OPTIONS as opt (opt)}
-                <option value={opt}>{opt}</option>
+              {#each RELEVANCE_OPTIONS as opt (opt.value)}
+                <option value={opt.value}>{opt.label}</option>
               {/each}
             </select>
           </div>

--- a/apps/affiliation-rating-resolver/src/App.svelte
+++ b/apps/affiliation-rating-resolver/src/App.svelte
@@ -1,0 +1,356 @@
+<script lang="ts">
+  // The write half of the Augment-from-Affiliations CSV round-trip. Reimport
+  // a rating-edited CSV (uploaded through the existing Record Collector
+  // path), map columns once, then write relevance/relevance_note onto each
+  // row's `affiliations` edge via affiliation.rate. No match/create — every
+  // row's person + org already exist in canonical; this only resolves the
+  // lookup key (person_uuid, org_slug) and writes the rating. See
+  // context-v/specs/Augment-From-Affiliations.md.
+
+  import { onMount } from 'svelte';
+  import { workspace, type RecordSet, type Row } from '@augment-it/workspace';
+  import ColumnMapper from './components/ColumnMapper.svelte';
+  import { normalizeRatingRecord, guessMapping, MAPPING_NONE } from './lib/normalize';
+  import { rateAffiliation } from './lib/resolver-client';
+  import type { RatingFieldMapping, RatingNormRecord } from './lib/types';
+
+  const TOKEN_KEY = 'augment-it:session-token';
+  const WS_URL = 'ws://localhost:3001/ws';
+  const ACTIVE_RECORD_SET_KEY = 'augment-it:active-record-set';
+  const MAPPING_KEY_PREFIX = 'augment-it:affiliation-rating-resolver:mapping:';
+
+  let status = $state<'connecting' | 'open' | 'closed' | 'error'>('connecting');
+  let client = $state<string>('reach-edu');
+
+  let recordSets = $state<RecordSet[]>([]);
+  let selectedRecordSetId = $state<string | null>(
+    typeof localStorage !== 'undefined' ? localStorage.getItem(ACTIVE_RECORD_SET_KEY) : null,
+  );
+  let rows = $state<Row[]>([]);
+  let idx = $state<number>(0);
+
+  let mapping = $state<RatingFieldMapping | null>(null);
+  let showMapper = $state(false);
+
+  let rowBusy = $state(false);
+  let rowError = $state<string | null>(null);
+  let rowResult = $state<{ relevance: string } | null>(null);
+
+  let bulkRunning = $state(false);
+  let bulkApplied = $state(0);
+  let bulkSkippedBlank = $state(0);
+  let bulkFlagged = $state<{ row: number; person: string | null; error: string }[]>([]);
+
+  const selectedSet = $derived(
+    selectedRecordSetId ? recordSets.find((rs) => rs.record_set_id === selectedRecordSetId) ?? null : null,
+  );
+  const columns = $derived(selectedSet?.schema.fields.map((f) => f.name) ?? []);
+  const current = $derived(idx >= 0 && idx < rows.length ? rows[idx] : null);
+  const record = $derived<RatingNormRecord | null>(
+    current && mapping ? normalizeRatingRecord(current.fields as Record<string, unknown>, mapping) : null,
+  );
+
+  function onWorkspaceChanged(e: Event) {
+    const detail = (e as CustomEvent).detail as { client_id?: string } | undefined;
+    if (detail?.client_id) client = detail.client_id;
+    else void loadActiveClient();
+    rows = [];
+    idx = 0;
+    resetRowState();
+    void loadRecordSets();
+  }
+
+  // Fired by Record Collector (and any other remote) when the shared
+  // "active record set" changes — e.g. right after an upload. Without this,
+  // a remote that mounted earlier stays on whatever record_set_id was in
+  // localStorage at mount time, ignoring anything uploaded after. Same fix
+  // record-db-resolver already needed once (it was missing this same
+  // listener) — copying it here rather than rediscovering it.
+  function onActiveRecordSetChange(e: Event) {
+    const detail = (e as CustomEvent).detail as { record_set_id?: string } | undefined;
+    if (!detail?.record_set_id) return;
+    selectedRecordSetId = detail.record_set_id;
+    void loadRecordSets();
+  }
+
+  onMount(() => {
+    workspace.connect({
+      url: WS_URL,
+      getToken: () => localStorage.getItem(TOKEN_KEY),
+      saveToken: (t) => localStorage.setItem(TOKEN_KEY, t),
+      onStatus: (s) => (status = s),
+    });
+    void loadActiveClient();
+    void loadRecordSets();
+    window.addEventListener('augment-it:workspace-changed', onWorkspaceChanged);
+    window.addEventListener('augment-it:active-record-set-changed', onActiveRecordSetChange);
+    return () => {
+      window.removeEventListener('augment-it:workspace-changed', onWorkspaceChanged);
+      window.removeEventListener('augment-it:active-record-set-changed', onActiveRecordSetChange);
+    };
+  });
+
+  async function loadActiveClient() {
+    try {
+      const r = (await workspace.invoke('workspace.active', {})) as { active_client_id?: string };
+      if (r?.active_client_id) client = r.active_client_id;
+    } catch {
+      /* keep default */
+    }
+  }
+
+  async function loadRecordSets() {
+    try {
+      const r = (await workspace.invoke('record_set.list', {})) as { record_sets: RecordSet[] };
+      recordSets = r.record_sets.filter((rs) => !rs.archived);
+      if (selectedRecordSetId && recordSets.some((rs) => rs.record_set_id === selectedRecordSetId)) {
+        await selectRecordSet(selectedRecordSetId);
+      }
+    } catch (err) {
+      console.error('record_set.list', err);
+    }
+  }
+
+  async function selectRecordSet(record_set_id: string) {
+    selectedRecordSetId = record_set_id;
+    if (typeof localStorage !== 'undefined') localStorage.setItem(ACTIVE_RECORD_SET_KEY, record_set_id);
+    rows = [];
+    idx = 0;
+    resetRowState();
+    resetBulkState();
+    loadMapping(record_set_id);
+    try {
+      const r = (await workspace.invoke('row.list', { record_set_id })) as { rows: Row[] };
+      rows = r.rows.filter((row) => !(row.fields as Record<string, unknown>).archived);
+    } catch (err) {
+      console.error('row.list', err);
+    }
+  }
+
+  function loadMapping(record_set_id: string) {
+    const key = `${MAPPING_KEY_PREFIX}${record_set_id}`;
+    const stored = typeof localStorage !== 'undefined' ? localStorage.getItem(key) : null;
+    if (stored) {
+      try {
+        mapping = JSON.parse(stored) as RatingFieldMapping;
+        showMapper = false;
+        return;
+      } catch {
+        /* fall through to re-guess */
+      }
+    }
+    mapping = guessMapping(columns);
+    showMapper = true;
+  }
+
+  function saveMapping(m: RatingFieldMapping) {
+    mapping = m;
+    showMapper = false;
+    if (selectedRecordSetId && typeof localStorage !== 'undefined') {
+      localStorage.setItem(`${MAPPING_KEY_PREFIX}${selectedRecordSetId}`, JSON.stringify(m));
+    }
+  }
+
+  function resetRowState() {
+    rowBusy = false;
+    rowError = null;
+    rowResult = null;
+  }
+  function resetBulkState() {
+    bulkRunning = false;
+    bulkApplied = 0;
+    bulkSkippedBlank = 0;
+    bulkFlagged = [];
+  }
+
+  async function applyCurrent() {
+    if (!record || !record.relevance) return;
+    rowBusy = true;
+    rowError = null;
+    try {
+      const r = await rateAffiliation({
+        person_uuid: record.person_uuid,
+        org_slug: record.org_slug,
+        relevance: record.relevance,
+        relevance_note: record.relevance_note,
+        client,
+      });
+      rowResult = { relevance: r.relevance };
+    } catch (err) {
+      rowError = err instanceof Error ? err.message : String(err);
+    } finally {
+      rowBusy = false;
+    }
+  }
+
+  function advance() {
+    idx = Math.min(idx + 1, rows.length);
+    resetRowState();
+  }
+  function back() {
+    idx = Math.max(0, idx - 1);
+    resetRowState();
+  }
+
+  // Bulk pass — the operator already made every judgment call in the
+  // spreadsheet; this is a mechanical write pass, not a review UI. Still
+  // flags rather than swallows anything that fails (unrecognized relevance
+  // value, no matching affiliation edge) — same discipline as the per-row
+  // path, just run without stopping to click through 61 rows one at a time.
+  async function applyAllRemaining() {
+    if (!mapping) return;
+    bulkRunning = true;
+    bulkApplied = 0;
+    bulkSkippedBlank = 0;
+    bulkFlagged = [];
+    for (let i = idx; i < rows.length; i += 1) {
+      const rec = normalizeRatingRecord(rows[i].fields as Record<string, unknown>, mapping);
+      if (!rec.relevance) {
+        bulkSkippedBlank += 1;
+        continue;
+      }
+      try {
+        await rateAffiliation({
+          person_uuid: rec.person_uuid,
+          org_slug: rec.org_slug,
+          relevance: rec.relevance,
+          relevance_note: rec.relevance_note,
+          client,
+        });
+        bulkApplied += 1;
+      } catch (err) {
+        bulkFlagged.push({
+          row: i + 1,
+          person: rec.person_name,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    idx = rows.length;
+    bulkRunning = false;
+  }
+</script>
+
+<div class="arr-app">
+  <header class="arr-header">
+    <div class="arr-title-row">
+      <h1 class="arr-title">Affiliation · Rating Resolver</h1>
+      <span class="arr-client">client: <strong>{client}</strong></span>
+      <span class="arr-ws status-{status}">{status}</span>
+    </div>
+    <div class="arr-setpick">
+      <label for="arr-set">record set</label>
+      <select
+        id="arr-set"
+        bind:value={selectedRecordSetId}
+        onchange={() => selectedRecordSetId && void selectRecordSet(selectedRecordSetId)}
+      >
+        <option value={null}>— pick the reimported ratings record set —</option>
+        {#each recordSets as rs (rs.record_set_id)}
+          <option value={rs.record_set_id}>{rs.name} ({rs.row_ids.length} rows)</option>
+        {/each}
+      </select>
+      {#if rows.length}
+        <span class="arr-progress">{Math.min(idx + 1, rows.length)} / {rows.length}</span>
+        <button type="button" class="arr-btn" onclick={() => (showMapper = true)}>edit column mapping</button>
+      {/if}
+    </div>
+  </header>
+
+  <main class="arr-body">
+    {#if !selectedSet}
+      <div class="arr-card arr-muted">
+        Pick the record set created by uploading the edited ratings CSV (from
+        <code>scripts/export-affiliation-ratings-csv.mjs</code>) through Record Collector.
+      </div>
+    {:else if showMapper && mapping}
+      <ColumnMapper
+        recordSetName={selectedSet.name}
+        {columns}
+        {mapping}
+        onSave={saveMapping}
+        onCancel={() => (showMapper = false)}
+        onPickDifferent={() => {
+          selectedRecordSetId = null;
+          if (typeof localStorage !== 'undefined') localStorage.removeItem(ACTIVE_RECORD_SET_KEY);
+          rows = [];
+          idx = 0;
+          mapping = null;
+          showMapper = false;
+          resetRowState();
+        }}
+      />
+    {:else if mapping}
+      <div class="arr-actions">
+        <button type="button" class="arr-btn arr-btn-primary" disabled={bulkRunning} onclick={applyAllRemaining}>
+          {bulkRunning ? 'applying…' : `apply all remaining ratings (from row ${idx + 1})`}
+        </button>
+      </div>
+
+      {#if bulkApplied || bulkSkippedBlank || bulkFlagged.length}
+        <div class="arr-card arr-bulk-summary">
+          <div class="arr-summary">
+            <span class="arr-summary-ok">✓ {bulkApplied} applied</span>
+            <span class="arr-muted">· {bulkSkippedBlank} left blank in the CSV (untouched)</span>
+            {#if bulkFlagged.length}<span class="arr-summary-flag">· {bulkFlagged.length} flagged</span>{/if}
+          </div>
+          {#if bulkFlagged.length}
+            <ul class="arr-flag-list">
+              {#each bulkFlagged as f}
+                <li class="arr-error">row {f.row}{f.person ? ` (${f.person})` : ''}: {f.error}</li>
+              {/each}
+            </ul>
+          {/if}
+        </div>
+      {/if}
+
+      {#if !current}
+        <div class="arr-card">
+          <h3>All done</h3>
+          <p class="arr-muted">No more rows in this set. ← back to revisit.</p>
+          <button type="button" class="arr-btn" onclick={back} disabled={idx === 0}>← back</button>
+        </div>
+      {:else if record}
+        <div class="arr-card">
+          <div class="arr-row-head">
+            <h3 class="arr-row-title">{record.person_name ?? record.person_uuid}</h3>
+            <span class="arr-row-org">{record.org_name ?? record.org_slug}</span>
+          </div>
+
+          <div class="arr-field">
+            <span class="arr-label">relevance (from CSV)</span>
+            {#if record.relevance}
+              <span class="arr-value">{record.relevance}</span>
+            {:else}
+              <span class="arr-muted">— left blank in the CSV, skipping this row —</span>
+            {/if}
+          </div>
+          {#if record.relevance_note}
+            <div class="arr-field">
+              <span class="arr-label">note</span>
+              <span class="arr-value">{record.relevance_note}</span>
+            </div>
+          {/if}
+
+          {#if rowError}<div class="arr-error">{rowError}</div>{/if}
+
+          {#if rowResult}
+            <div class="arr-result">
+              <div class="arr-result-head">✓ applied — <strong>{rowResult.relevance}</strong></div>
+            </div>
+          {:else if record.relevance}
+            <button type="button" class="arr-btn arr-btn-primary" disabled={rowBusy} onclick={applyCurrent}>
+              apply this rating
+            </button>
+          {/if}
+        </div>
+
+        <div class="arr-actions">
+          <button type="button" class="arr-btn" onclick={back} disabled={idx === 0}>← back</button>
+          <span class="arr-spacer"></span>
+          <button type="button" class="arr-btn arr-btn-primary" onclick={advance}>next →</button>
+        </div>
+      {/if}
+    {/if}
+  </main>
+</div>

--- a/apps/affiliation-rating-resolver/src/App.svelte
+++ b/apps/affiliation-rating-resolver/src/App.svelte
@@ -11,8 +11,16 @@
   import { workspace, type RecordSet, type Row } from '@augment-it/workspace';
   import ColumnMapper from './components/ColumnMapper.svelte';
   import { normalizeRatingRecord, guessMapping, MAPPING_NONE } from './lib/normalize';
-  import { rateAffiliation } from './lib/resolver-client';
-  import type { RatingFieldMapping, RatingNormRecord } from './lib/types';
+  import {
+    rateAffiliation,
+    fetchAffiliationDetail,
+    addPersonLink,
+    addPersonCorpus,
+    addOrgLink,
+    addOrgCorpus,
+  } from './lib/resolver-client';
+  import { RELEVANCE_OPTIONS } from './lib/types';
+  import type { RatingFieldMapping, RatingNormRecord, AffiliationDetail, Link, CorpusEntry } from './lib/types';
 
   const TOKEN_KEY = 'augment-it:session-token';
   const WS_URL = 'ws://localhost:3001/ws';
@@ -41,6 +49,31 @@
   let bulkSkippedBlank = $state(0);
   let bulkFlagged = $state<{ row: number; person: string | null; error: string }[]>([]);
 
+  // ---- Inline editing state — the per-row "view the record, edit it in
+  // place" surface, same shape as record-db-resolver / person-db-resolver.
+  // Hydrated fresh via affiliation.detail whenever the row changes, so it
+  // reflects the CURRENT canonical state, not a stale CSV-export snapshot.
+  let detailLoading = $state(false);
+  let detailError = $state<string | null>(null);
+  let detail = $state<AffiliationDetail | null>(null);
+
+  let relevanceInput = $state<string>('');
+  let relevanceNoteInput = $state<string>('');
+
+  let personLinkUrl = $state('');
+  let personLinkBusy = $state(false);
+  let personLinkError = $state<string | null>(null);
+  let personCorpusUrl = $state('');
+  let personCorpusBusy = $state(false);
+  let personCorpusError = $state<string | null>(null);
+
+  let orgLinkUrl = $state('');
+  let orgLinkBusy = $state(false);
+  let orgLinkError = $state<string | null>(null);
+  let orgCorpusUrl = $state('');
+  let orgCorpusBusy = $state(false);
+  let orgCorpusError = $state<string | null>(null);
+
   const selectedSet = $derived(
     selectedRecordSetId ? recordSets.find((rs) => rs.record_set_id === selectedRecordSetId) ?? null : null,
   );
@@ -49,6 +82,53 @@
   const record = $derived<RatingNormRecord | null>(
     current && mapping ? normalizeRatingRecord(current.fields as Record<string, unknown>, mapping) : null,
   );
+
+  // Load fresh detail whenever the row's identity changes. Only reads
+  // record?.person_uuid / record?.org_slug — never relevanceInput or
+  // anything this effect itself writes, same "don't transitively read your
+  // own output" rule person-db-resolver's App.svelte already learned the
+  // hard way (see that file's header comment on the row-change effect).
+  $effect(() => {
+    const person_uuid = record?.person_uuid;
+    const org_slug = record?.org_slug;
+    if (!person_uuid || !org_slug) {
+      detail = null;
+      return;
+    }
+    void loadDetailFor(person_uuid, org_slug);
+  });
+
+  async function loadDetailFor(person_uuid: string, org_slug: string) {
+    detailLoading = true;
+    detailError = null;
+    resetLinkCorpusState();
+    try {
+      const d = await fetchAffiliationDetail(person_uuid, org_slug);
+      detail = d;
+      // Server's current rating wins over the CSV pre-fill once loaded;
+      // the CSV value is still shown as a fallback while this is loading.
+      relevanceInput = d.relevance ?? record?.relevance ?? '';
+      relevanceNoteInput = d.relevance_note ?? record?.relevance_note ?? '';
+    } catch (err) {
+      detail = null;
+      detailError = err instanceof Error ? err.message : String(err);
+      relevanceInput = record?.relevance ?? '';
+      relevanceNoteInput = record?.relevance_note ?? '';
+    } finally {
+      detailLoading = false;
+    }
+  }
+
+  function resetLinkCorpusState() {
+    personLinkUrl = '';
+    personLinkError = null;
+    personCorpusUrl = '';
+    personCorpusError = null;
+    orgLinkUrl = '';
+    orgLinkError = null;
+    orgCorpusUrl = '';
+    orgCorpusError = null;
+  }
 
   function onWorkspaceChanged(e: Event) {
     const detail = (e as CustomEvent).detail as { client_id?: string } | undefined;
@@ -164,15 +244,15 @@
   }
 
   async function applyCurrent() {
-    if (!record || !record.relevance) return;
+    if (!record || !relevanceInput.trim()) return;
     rowBusy = true;
     rowError = null;
     try {
       const r = await rateAffiliation({
         person_uuid: record.person_uuid,
         org_slug: record.org_slug,
-        relevance: record.relevance,
-        relevance_note: record.relevance_note,
+        relevance: relevanceInput,
+        relevance_note: relevanceNoteInput,
         client,
       });
       rowResult = { relevance: r.relevance };
@@ -180,6 +260,73 @@
       rowError = err instanceof Error ? err.message : String(err);
     } finally {
       rowBusy = false;
+    }
+  }
+
+  // ---- Person-side link/corpus add — commits immediately, same
+  // "each add is its own write" discipline as record-db-resolver /
+  // person-db-resolver's match/create actions.
+  async function submitPersonLink() {
+    const url = personLinkUrl.trim();
+    if (!url || !record || !detail) return;
+    personLinkBusy = true;
+    personLinkError = null;
+    try {
+      const link = await addPersonLink({ person_uuid: record.person_uuid, url, client });
+      detail = { ...detail, person: { ...detail.person, personal_links: [...detail.person.personal_links, link] } };
+      personLinkUrl = '';
+    } catch (err) {
+      personLinkError = err instanceof Error ? err.message : String(err);
+    } finally {
+      personLinkBusy = false;
+    }
+  }
+
+  async function submitPersonCorpus() {
+    const url = personCorpusUrl.trim();
+    if (!url || !record || !detail) return;
+    personCorpusBusy = true;
+    personCorpusError = null;
+    try {
+      const entry = await addPersonCorpus({ person_uuid: record.person_uuid, url, client });
+      detail = { ...detail, person: { ...detail.person, personal_corpus: [...detail.person.personal_corpus, entry] } };
+      personCorpusUrl = '';
+    } catch (err) {
+      personCorpusError = err instanceof Error ? err.message : String(err);
+    } finally {
+      personCorpusBusy = false;
+    }
+  }
+
+  async function submitOrgLink() {
+    const url = orgLinkUrl.trim();
+    if (!url || !record || !detail) return;
+    orgLinkBusy = true;
+    orgLinkError = null;
+    try {
+      const link = await addOrgLink({ org_slug: record.org_slug, url, client });
+      detail = { ...detail, org: { ...detail.org, org_links: [...detail.org.org_links, link] } };
+      orgLinkUrl = '';
+    } catch (err) {
+      orgLinkError = err instanceof Error ? err.message : String(err);
+    } finally {
+      orgLinkBusy = false;
+    }
+  }
+
+  async function submitOrgCorpus() {
+    const url = orgCorpusUrl.trim();
+    if (!url || !record || !detail) return;
+    orgCorpusBusy = true;
+    orgCorpusError = null;
+    try {
+      const entry = await addOrgCorpus({ org_slug: record.org_slug, url, client });
+      detail = { ...detail, org: { ...detail.org, org_corpus: [...detail.org.org_corpus, entry] } };
+      orgCorpusUrl = '';
+    } catch (err) {
+      orgCorpusError = err instanceof Error ? err.message : String(err);
+    } finally {
+      orgCorpusBusy = false;
     }
   }
 
@@ -313,36 +460,115 @@
       {:else if record}
         <div class="arr-card">
           <div class="arr-row-head">
-            <h3 class="arr-row-title">{record.person_name ?? record.person_uuid}</h3>
-            <span class="arr-row-org">{record.org_name ?? record.org_slug}</span>
+            <h3 class="arr-row-title">{detail?.person.name ?? record.person_name ?? record.person_uuid}</h3>
+            <span class="arr-row-org">{detail?.org.complete_name ?? record.org_name ?? record.org_slug}</span>
+            {#if detail?.kind}<span class="arr-row-role">{detail.kind}</span>{/if}
           </div>
+
+          {#if detailLoading}<p class="arr-muted">loading current state…</p>{/if}
+          {#if detailError}<div class="arr-error">couldn't load current state: {detailError} — falling back to the CSV-supplied values.</div>{/if}
 
           <div class="arr-field">
-            <span class="arr-label">relevance (from CSV)</span>
-            {#if record.relevance}
-              <span class="arr-value">{record.relevance}</span>
-            {:else}
-              <span class="arr-muted">— left blank in the CSV, skipping this row —</span>
-            {/if}
+            <label class="arr-label" for="arr-relevance">relevance</label>
+            <select id="arr-relevance" bind:value={relevanceInput}>
+              <option value="">— not rated —</option>
+              {#each RELEVANCE_OPTIONS as opt (opt)}
+                <option value={opt}>{opt}</option>
+              {/each}
+            </select>
           </div>
-          {#if record.relevance_note}
-            <div class="arr-field">
-              <span class="arr-label">note</span>
-              <span class="arr-value">{record.relevance_note}</span>
-            </div>
-          {/if}
+          <div class="arr-field">
+            <label class="arr-label" for="arr-relevance-note">note</label>
+            <textarea id="arr-relevance-note" bind:value={relevanceNoteInput} rows="2" placeholder="why this rating — helps whoever reads the export later"></textarea>
+          </div>
 
           {#if rowError}<div class="arr-error">{rowError}</div>{/if}
-
           {#if rowResult}
             <div class="arr-result">
               <div class="arr-result-head">✓ applied — <strong>{rowResult.relevance}</strong></div>
             </div>
-          {:else if record.relevance}
-            <button type="button" class="arr-btn arr-btn-primary" disabled={rowBusy} onclick={applyCurrent}>
-              apply this rating
-            </button>
           {/if}
+          <button type="button" class="arr-btn arr-btn-primary" disabled={rowBusy || !relevanceInput.trim()} onclick={applyCurrent}>
+            {rowBusy ? 'applying…' : 'apply this rating'}
+          </button>
+
+          <div class="arr-two-col">
+            <section class="arr-subsection">
+              <h4 class="arr-eyebrow">person links</h4>
+              {#if detail?.person.personal_links.length}
+                <ul class="arr-link-list">
+                  {#each detail.person.personal_links as l}
+                    <li><a href={l.url} target="_blank" rel="noopener">{l.url}</a> <code class="arr-kind">{l.kind}</code></li>
+                  {/each}
+                </ul>
+              {:else}
+                <p class="arr-muted">none yet</p>
+              {/if}
+              <div class="arr-add-row">
+                <input type="url" bind:value={personLinkUrl} placeholder="paste a canonical link (LinkedIn, website, X…)" disabled={!detail}
+                  onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void submitPersonLink(); } }} />
+                <button type="button" class="arr-btn" disabled={personLinkBusy || !personLinkUrl.trim() || !detail} onclick={submitPersonLink}>+ add</button>
+              </div>
+              {#if personLinkError}<div class="arr-error">{personLinkError}</div>{/if}
+            </section>
+
+            <section class="arr-subsection">
+              <h4 class="arr-eyebrow">person corpus</h4>
+              {#if detail?.person.personal_corpus.length}
+                <ul class="arr-link-list">
+                  {#each detail.person.personal_corpus as l}
+                    <li><a href={l.url} target="_blank" rel="noopener">{l.url}</a> <code class="arr-kind">{l.kind}</code></li>
+                  {/each}
+                </ul>
+              {:else}
+                <p class="arr-muted">none yet</p>
+              {/if}
+              <div class="arr-add-row">
+                <input type="url" bind:value={personCorpusUrl} placeholder="content ABOUT them — a press mention, an interview" disabled={!detail}
+                  onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void submitPersonCorpus(); } }} />
+                <button type="button" class="arr-btn" disabled={personCorpusBusy || !personCorpusUrl.trim() || !detail} onclick={submitPersonCorpus}>+ add</button>
+              </div>
+              {#if personCorpusError}<div class="arr-error">{personCorpusError}</div>{/if}
+            </section>
+
+            <section class="arr-subsection">
+              <h4 class="arr-eyebrow">org links</h4>
+              {#if detail?.org.org_links.length}
+                <ul class="arr-link-list">
+                  {#each detail.org.org_links as l}
+                    <li><a href={l.url} target="_blank" rel="noopener">{l.url}</a> <code class="arr-kind">{l.kind}</code></li>
+                  {/each}
+                </ul>
+              {:else}
+                <p class="arr-muted">none yet</p>
+              {/if}
+              <div class="arr-add-row">
+                <input type="url" bind:value={orgLinkUrl} placeholder="paste a canonical link (website, LinkedIn company…)" disabled={!detail}
+                  onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void submitOrgLink(); } }} />
+                <button type="button" class="arr-btn" disabled={orgLinkBusy || !orgLinkUrl.trim() || !detail} onclick={submitOrgLink}>+ add</button>
+              </div>
+              {#if orgLinkError}<div class="arr-error">{orgLinkError}</div>{/if}
+            </section>
+
+            <section class="arr-subsection">
+              <h4 class="arr-eyebrow">org corpus</h4>
+              {#if detail?.org.org_corpus.length}
+                <ul class="arr-link-list">
+                  {#each detail.org.org_corpus as l}
+                    <li><a href={l.url} target="_blank" rel="noopener">{l.url}</a> <code class="arr-kind">{l.kind}</code></li>
+                  {/each}
+                </ul>
+              {:else}
+                <p class="arr-muted">none yet</p>
+              {/if}
+              <div class="arr-add-row">
+                <input type="url" bind:value={orgCorpusUrl} placeholder="content ABOUT the org — press, a feature" disabled={!detail}
+                  onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); void submitOrgCorpus(); } }} />
+                <button type="button" class="arr-btn" disabled={orgCorpusBusy || !orgCorpusUrl.trim() || !detail} onclick={submitOrgCorpus}>+ add</button>
+              </div>
+              {#if orgCorpusError}<div class="arr-error">{orgCorpusError}</div>{/if}
+            </section>
+          </div>
         </div>
 
         <div class="arr-actions">

--- a/apps/affiliation-rating-resolver/src/app.css
+++ b/apps/affiliation-rating-resolver/src/app.css
@@ -1,0 +1,81 @@
+/* affiliation-rating-resolver — scoped arr-* surface styles. Uses
+   @augment-it/theme :root tokens with literal fallbacks so the remote
+   still renders standalone if a token is absent. Trimmed subset of
+   person-db-resolver's pdr-* sheet — same tokens, same shapes, no
+   candidate-list / mapper-row types this app doesn't need. */
+
+.arr-app {
+  font-family: var(--font-sans, system-ui, -apple-system, sans-serif);
+  color: var(--color-text, #e7e7e7);
+  padding: 0.5rem 1.25rem 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.arr-header { position: sticky; top: 0; z-index: 2; padding: 0.75rem 0; background: var(--color-bg, #14151a); border-bottom: 1px solid var(--color-border, #2a2c33); }
+.arr-title-row { display: flex; align-items: baseline; gap: 0.75rem; }
+.arr-title { font-size: 1.05rem; margin: 0; }
+.arr-client { font-size: 0.8rem; color: var(--color-text-muted, #9aa0aa); }
+.arr-ws { margin-left: auto; font-size: 0.7rem; padding: 1px 7px; border-radius: 3px; background: var(--color-border, #2a2c33); }
+.arr-ws.status-open { background: var(--color-ok-bg, #173a26); color: var(--color-ok-text, #6ee7a8); }
+.arr-ws.status-closed, .arr-ws.status-error { background: var(--color-error-bg, #3a1717); color: var(--color-error-text, #f3a3a3); }
+
+.arr-setpick { display: flex; align-items: center; gap: 0.5rem; margin-top: 0.5rem; font-size: 0.85rem; flex-wrap: wrap; }
+.arr-setpick label { color: var(--color-text-muted, #9aa0aa); }
+.arr-setpick select { background: var(--color-surface, #1c1e25); color: inherit; border: 1px solid var(--color-border, #2a2c33); border-radius: 4px; padding: 0.3rem 0.5rem; min-width: 18rem; }
+.arr-progress { margin-left: auto; color: var(--color-text-muted, #9aa0aa); font-variant-numeric: tabular-nums; }
+.arr-summary { display: flex; gap: 0.75rem; font-size: 0.78rem; }
+.arr-summary-ok { color: var(--color-ok-text, #6ee7a8); }
+.arr-summary-flag { color: var(--color-error-text, #f3a3a3); }
+
+.arr-body { margin-top: 1rem; }
+
+.arr-card { background: var(--color-surface, #1c1e25); border: 1px solid var(--color-border, #2a2c33); border-radius: 8px; padding: 1rem; }
+.arr-muted { color: var(--color-text-muted, #9aa0aa); }
+.arr-eyebrow { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-muted, #9aa0aa); }
+
+.arr-row-head { margin-bottom: 0.5rem; }
+.arr-row-title { font-size: 1.1rem; margin: 0.15rem 0; }
+.arr-row-org { color: var(--color-text-muted, #9aa0aa); }
+.arr-row-role { font-style: italic; }
+.arr-field { margin: 0.5rem 0; }
+.arr-label { display: block; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-text-muted, #9aa0aa); margin-bottom: 0.2rem; }
+.arr-value { font-size: 0.9rem; }
+
+.arr-result { background: var(--color-ok-bg, #173a26); border: 1px solid var(--color-ok-text, #6ee7a8); border-radius: 8px; padding: 0.7rem; margin-top: 0.6rem; }
+.arr-result-head { font-weight: 600; }
+.arr-stamp-ok { font-size: 0.7rem; font-weight: 500; color: var(--color-ok-text, #6ee7a8); border: 1px solid var(--color-ok-text, #6ee7a8); border-radius: 3px; padding: 0 0.35rem; }
+
+.arr-error { background: var(--color-error-bg, #3a1717); color: var(--color-error-text, #f3a3a3); border-radius: 6px; padding: 0.5rem 0.7rem; font-size: 0.8rem; margin-top: 0.5rem; }
+.arr-skip-note { border-style: dashed; color: var(--color-text-muted, #9aa0aa); }
+
+.arr-actions { display: flex; align-items: center; margin-top: 1rem; gap: 0.6rem; }
+.arr-spacer { flex: 1; }
+
+.arr-btn { background: var(--color-surface, #1c1e25); color: inherit; border: 1px solid var(--color-border, #2a2c33); border-radius: 5px; padding: 0.4rem 0.8rem; cursor: pointer; font-size: 0.85rem; }
+.arr-btn:hover:not(:disabled) { border-color: var(--color-text-muted, #9aa0aa); }
+.arr-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.arr-btn-primary { background: var(--color-accent, #5b7cfa); color: #fff; border-color: transparent; }
+
+.arr-pick-different {
+  margin-bottom: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--color-accent, #5b7cfa);
+  background: transparent;
+  border-color: transparent;
+  padding-left: 0;
+}
+.arr-pick-different:hover {
+  text-decoration: underline;
+}
+
+/* Column mapper */
+.arr-mapper-rows { display: flex; flex-direction: column; gap: 0.5rem; margin: 0.75rem 0; }
+.arr-mapper-row { display: grid; grid-template-columns: 14rem 1fr; align-items: center; gap: 0.5rem; font-size: 0.85rem; }
+.arr-mapper-row select { background: var(--color-bg, #14151a); color: inherit; border: 1px solid var(--color-border, #2a2c33); border-radius: 4px; padding: 0.35rem 0.5rem; }
+.arr-mapper-actions { display: flex; gap: 0.6rem; margin-top: 0.5rem; }
+
+/* Bulk-apply summary */
+.arr-bulk-summary { margin-top: 0.5rem; }
+.arr-flag-list { list-style: none; margin: 0.4rem 0 0; padding: 0; display: flex; flex-direction: column; gap: 0.3rem; }
+.arr-flag-list li { font-size: 0.8rem; }

--- a/apps/affiliation-rating-resolver/src/app.css
+++ b/apps/affiliation-rating-resolver/src/app.css
@@ -34,13 +34,27 @@
 .arr-muted { color: var(--color-text-muted, #9aa0aa); }
 .arr-eyebrow { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-text-muted, #9aa0aa); }
 
-.arr-row-head { margin-bottom: 0.5rem; }
+.arr-row-head { margin-bottom: 0.5rem; display: flex; align-items: baseline; gap: 0.6rem; flex-wrap: wrap; }
 .arr-row-title { font-size: 1.1rem; margin: 0.15rem 0; }
 .arr-row-org { color: var(--color-text-muted, #9aa0aa); }
-.arr-row-role { font-style: italic; }
+.arr-row-role { font-style: italic; font-size: 0.85rem; color: var(--color-text-muted, #9aa0aa); }
 .arr-field { margin: 0.5rem 0; }
 .arr-label { display: block; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--color-text-muted, #9aa0aa); margin-bottom: 0.2rem; }
 .arr-value { font-size: 0.9rem; }
+.arr-field select, .arr-field textarea { width: 100%; max-width: 28rem; background: var(--color-bg, #14151a); color: inherit; border: 1px solid var(--color-border, #2a2c33); border-radius: 4px; padding: 0.4rem 0.5rem; font: inherit; font-size: 0.85rem; }
+.arr-field textarea { resize: vertical; }
+
+.arr-two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 1rem; padding-top: 1rem; border-top: 1px dashed var(--color-border, #2a2c33); }
+@media (max-width: 700px) { .arr-two-col { grid-template-columns: 1fr; } }
+.arr-subsection { display: flex; flex-direction: column; gap: 0.4rem; }
+.arr-link-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.25rem; }
+.arr-link-list li { font-size: 0.8rem; word-break: break-all; display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; }
+.arr-link-list a { color: var(--color-link, #6fb3ff); text-decoration: none; }
+.arr-link-list a:hover { text-decoration: underline; }
+.arr-kind { font-size: 0.65rem; color: var(--color-text-muted, #9aa0aa); border: 1px solid var(--color-border, #2a2c33); border-radius: 3px; padding: 0 0.3rem; white-space: nowrap; }
+.arr-add-row { display: flex; gap: 0.4rem; }
+.arr-add-row input { flex: 1; min-width: 0; background: var(--color-bg, #14151a); color: inherit; border: 1px solid var(--color-border, #2a2c33); border-radius: 4px; padding: 0.35rem 0.5rem; font-size: 0.8rem; }
+.arr-add-row input:disabled { opacity: 0.5; }
 
 .arr-result { background: var(--color-ok-bg, #173a26); border: 1px solid var(--color-ok-text, #6ee7a8); border-radius: 8px; padding: 0.7rem; margin-top: 0.6rem; }
 .arr-result-head { font-weight: 600; }

--- a/apps/affiliation-rating-resolver/src/components/ColumnMapper.svelte
+++ b/apps/affiliation-rating-resolver/src/components/ColumnMapper.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  // Asked once per record set, not per row — same pattern as
+  // person-db-resolver's ColumnMapper. Pre-filled by guessMapping (matches
+  // export-affiliation-ratings-csv.mjs's own column names on the first
+  // pass), the operator confirms or corrects, then it's remembered.
+
+  import type { RatingFieldMapping } from '../lib/types';
+  import { MAPPING_NONE } from '../lib/normalize';
+
+  let {
+    recordSetName,
+    columns,
+    mapping,
+    onSave,
+    onCancel,
+    onPickDifferent,
+  }: {
+    recordSetName: string;
+    columns: string[];
+    mapping: RatingFieldMapping;
+    onSave: (m: RatingFieldMapping) => void;
+    onCancel: () => void;
+    onPickDifferent: () => void;
+  } = $props();
+
+  let draft = $state<RatingFieldMapping>({ ...mapping });
+
+  const FIELDS: { key: keyof RatingFieldMapping; label: string; required: boolean }[] = [
+    { key: 'person_uuid', label: 'person_uuid (reimport key)', required: true },
+    { key: 'org_slug', label: 'org_slug (reimport key)', required: true },
+    { key: 'relevance', label: 'Relevance', required: true },
+    { key: 'relevance_note', label: 'Relevance note', required: false },
+    { key: 'person_name', label: 'Person name (display only)', required: false },
+    { key: 'org_name', label: 'Org name (display only)', required: false },
+  ];
+
+  // Loud, specific warning when the required reimport-key columns aren't in
+  // this file at all — the single most common way an operator ends up here
+  // confused: they're on the wrong record set (e.g. the raw speakers CSV,
+  // not the ratings export), not actually facing a hard mapping choice.
+  const looksWrong = $derived(!columns.includes('person_uuid') && !columns.includes('org_slug'));
+
+  function save() {
+    onSave(draft);
+  }
+</script>
+
+<div class="arr-card arr-mapper">
+  <button type="button" class="arr-btn arr-pick-different" onclick={onPickDifferent}>
+    ← wrong file? pick a different record set
+  </button>
+  <h3>Map this record set's columns</h3>
+  <p class="arr-muted">
+    Asked once per record set — every row in <strong>{recordSetName}</strong> reuses this.
+    <code>person_uuid</code> / <code>org_slug</code> are the reimport key — don't map them to a
+    column the operator hand-edited.
+  </p>
+  {#if looksWrong}
+    <div class="arr-error">
+      This file has no <code>person_uuid</code> or <code>org_slug</code> column at all — it's
+      almost certainly not the ratings CSV from
+      <code>scripts/export-affiliation-ratings-csv.mjs</code>. Click "← wrong file?" above and
+      pick the correct record set instead of mapping these columns.
+    </div>
+  {/if}
+  <div class="arr-mapper-rows">
+    {#each FIELDS as f (f.key)}
+      <label class="arr-mapper-row">
+        <span>{f.label}{f.required ? ' *' : ''}</span>
+        <select bind:value={draft[f.key]}>
+          <option value={MAPPING_NONE}>{MAPPING_NONE}</option>
+          {#each columns as c (c)}
+            <option value={c}>{c}</option>
+          {/each}
+        </select>
+      </label>
+    {/each}
+  </div>
+  <div class="arr-mapper-actions">
+    <button
+      type="button"
+      class="arr-btn arr-btn-primary"
+      disabled={draft.person_uuid === MAPPING_NONE || draft.org_slug === MAPPING_NONE || draft.relevance === MAPPING_NONE}
+      onclick={save}
+    >
+      save mapping
+    </button>
+    <button type="button" class="arr-btn" onclick={onCancel}>cancel</button>
+  </div>
+</div>

--- a/apps/affiliation-rating-resolver/src/css.d.ts
+++ b/apps/affiliation-rating-resolver/src/css.d.ts
@@ -1,0 +1,5 @@
+// Side-effect CSS imports (./app.css, @augment-it/theme/theme.css) carry no
+// type declarations — rsbuild resolves them at build time. Declare them
+// ambiently so svelte-check / tsc (stricter under TS 6) can resolve the
+// side-effect imports instead of erroring on the missing module.
+declare module '*.css';

--- a/apps/affiliation-rating-resolver/src/index.ts
+++ b/apps/affiliation-rating-resolver/src/index.ts
@@ -1,0 +1,13 @@
+// Standalone entry (:3012). theme.css for tokens + mode-switcher for theme;
+// both load before app.css so component styles' var() refs resolve. In the
+// shell, mount.ts is the entry instead.
+import '@augment-it/theme/theme.css';
+import '@augment-it/theme/mode-switcher';
+import './app.css';
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+const target = document.getElementById('root');
+if (!target) throw new Error('no #root');
+
+mount(App, { target });

--- a/apps/affiliation-rating-resolver/src/lib/normalize.ts
+++ b/apps/affiliation-rating-resolver/src/lib/normalize.ts
@@ -1,0 +1,58 @@
+// row.fields → RatingNormRecord, using an explicit per-record-set column
+// mapping — same discipline person-db-resolver's normalize.ts established:
+// dynamic schema in, explicit mapping, never a hardcoded column-name
+// allowlist.
+
+import type { RatingFieldMapping, RatingNormRecord } from './types';
+
+const NONE = '(none)';
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v.trim() : v == null ? '' : String(v).trim();
+}
+
+export function normalizeRatingRecord(
+  fields: Record<string, unknown>,
+  mapping: RatingFieldMapping,
+): RatingNormRecord {
+  const get = (col: string): string => (col && col !== NONE ? str(fields[col]) : '');
+  return {
+    person_uuid: get(mapping.person_uuid),
+    org_slug: get(mapping.org_slug),
+    relevance: get(mapping.relevance),
+    relevance_note: get(mapping.relevance_note) || null,
+    person_name: get(mapping.person_name) || null,
+    org_name: get(mapping.org_name) || null,
+  };
+}
+
+// Best-guess default mapping from export-affiliation-ratings-csv.mjs's own
+// column names — matches on the first pass, so the mapping step is usually
+// just a confirm-click, not real typing.
+const GUESSES: Record<keyof RatingFieldMapping, string[]> = {
+  person_uuid: ['person_uuid'],
+  org_slug: ['org_slug'],
+  relevance: ['relevance'],
+  relevance_note: ['relevance_note'],
+  person_name: ['person_name', 'name'],
+  org_name: ['org_name', 'organization'],
+};
+
+export function guessMapping(columns: string[]): RatingFieldMapping {
+  const pick = (field: keyof RatingFieldMapping): string => {
+    for (const candidate of GUESSES[field]) {
+      if (columns.includes(candidate)) return candidate;
+    }
+    return NONE;
+  };
+  return {
+    person_uuid: pick('person_uuid'),
+    org_slug: pick('org_slug'),
+    relevance: pick('relevance'),
+    relevance_note: pick('relevance_note'),
+    person_name: pick('person_name'),
+    org_name: pick('org_name'),
+  };
+}
+
+export { NONE as MAPPING_NONE };

--- a/apps/affiliation-rating-resolver/src/lib/resolver-client.ts
+++ b/apps/affiliation-rating-resolver/src/lib/resolver-client.ts
@@ -1,0 +1,18 @@
+// Thin typed wrapper over workspace.invoke('affiliation.rate'). The UI never
+// talks to a database — this goes WS → workspace-service → NATS →
+// record-surrealdb-resolver, same as every other resolver remote.
+
+import { workspace } from '@augment-it/workspace';
+import type { AffiliationRateResult } from './types';
+
+export async function rateAffiliation(args: {
+  person_uuid: string;
+  org_slug: string;
+  relevance: string;
+  relevance_note?: string | null;
+  client: string;
+}): Promise<AffiliationRateResult> {
+  const r = (await workspace.invoke('affiliation.rate', args)) as AffiliationRateResult;
+  if (!r.ok) throw new Error(r.error || 'affiliation.rate failed');
+  return r;
+}

--- a/apps/affiliation-rating-resolver/src/lib/resolver-client.ts
+++ b/apps/affiliation-rating-resolver/src/lib/resolver-client.ts
@@ -1,9 +1,9 @@
-// Thin typed wrapper over workspace.invoke('affiliation.rate'). The UI never
-// talks to a database — this goes WS → workspace-service → NATS →
+// Thin typed wrappers over workspace.invoke(...). The UI never talks to a
+// database — every call goes WS → workspace-service → NATS →
 // record-surrealdb-resolver, same as every other resolver remote.
 
 import { workspace } from '@augment-it/workspace';
-import type { AffiliationRateResult } from './types';
+import type { AffiliationRateResult, AffiliationDetail, Link, CorpusEntry } from './types';
 
 export async function rateAffiliation(args: {
   person_uuid: string;
@@ -15,4 +15,34 @@ export async function rateAffiliation(args: {
   const r = (await workspace.invoke('affiliation.rate', args)) as AffiliationRateResult;
   if (!r.ok) throw new Error(r.error || 'affiliation.rate failed');
   return r;
+}
+
+export async function fetchAffiliationDetail(person_uuid: string, org_slug: string): Promise<AffiliationDetail> {
+  const r = (await workspace.invoke('affiliation.detail', { person_uuid, org_slug })) as AffiliationDetail;
+  if (!r.ok) throw new Error(r.error || 'affiliation.detail failed');
+  return r;
+}
+
+export async function addPersonLink(args: { person_uuid: string; url: string; client: string }): Promise<Link> {
+  const r = (await workspace.invoke('person.links.add', args)) as { ok: boolean; link?: Link; error?: string };
+  if (!r.ok || !r.link) throw new Error(r.error || 'person.links.add failed');
+  return r.link;
+}
+
+export async function addPersonCorpus(args: { person_uuid: string; url: string; client: string }): Promise<CorpusEntry> {
+  const r = (await workspace.invoke('person.corpus.add', args)) as { ok: boolean; entry?: CorpusEntry; error?: string };
+  if (!r.ok || !r.entry) throw new Error(r.error || 'person.corpus.add failed');
+  return r.entry;
+}
+
+export async function addOrgLink(args: { org_slug: string; url: string; client: string }): Promise<Link> {
+  const r = (await workspace.invoke('organization.links.add', args)) as { ok: boolean; link?: Link; error?: string };
+  if (!r.ok || !r.link) throw new Error(r.error || 'organization.links.add failed');
+  return r.link;
+}
+
+export async function addOrgCorpus(args: { org_slug: string; url: string; client: string }): Promise<CorpusEntry> {
+  const r = (await workspace.invoke('organization.corpus.add', args)) as { ok: boolean; entry?: CorpusEntry; error?: string };
+  if (!r.ok || !r.entry) throw new Error(r.error || 'organization.corpus.add failed');
+  return r.entry;
 }

--- a/apps/affiliation-rating-resolver/src/lib/types.ts
+++ b/apps/affiliation-rating-resolver/src/lib/types.ts
@@ -57,10 +57,15 @@ export type AffiliationDetail = {
   error?: string;
 };
 
+// value = the canonical machine value affiliation.rate stores and
+// affiliation.detail returns (services/record-surrealdb-resolver/src/
+// person-resolver.ts's RELEVANCE_LABELS). Must match exactly, or a
+// previously-rated row's dropdown won't pre-select on reload — the bug
+// this shape fixes (values used to be the Title Case label only).
 export const RELEVANCE_OPTIONS = [
-  'Very Relevant',
-  'Highly Relevant',
-  'Relevant',
-  'Skip',
-  'Irrelevant',
+  { value: 'very_relevant', label: 'Very Relevant' },
+  { value: 'highly_relevant', label: 'Highly Relevant' },
+  { value: 'relevant', label: 'Relevant' },
+  { value: 'skip', label: 'Skip' },
+  { value: 'irrelevant', label: 'Irrelevant' },
 ] as const;

--- a/apps/affiliation-rating-resolver/src/lib/types.ts
+++ b/apps/affiliation-rating-resolver/src/lib/types.ts
@@ -31,3 +31,36 @@ export type AffiliationRateResult = {
   relevance: string;
   error?: string;
 };
+
+// Same canonical link shape resolver.ts/person-resolver.ts produce —
+// mirrored here for the frontend, same convention as PersonCandidate etc.
+export type Link = { url: string; kind: string; url_domain: string; added_at: string };
+export type CorpusEntry = Link & { content_id: unknown };
+
+export type AffiliationDetail = {
+  ok: boolean;
+  person: {
+    person_uuid: string;
+    name: string | null;
+    personal_links: Link[];
+    personal_corpus: CorpusEntry[];
+  };
+  org: {
+    org_slug: string;
+    complete_name: string | null;
+    org_links: Link[];
+    org_corpus: CorpusEntry[];
+  };
+  kind: string | null;
+  relevance: string | null;
+  relevance_note: string | null;
+  error?: string;
+};
+
+export const RELEVANCE_OPTIONS = [
+  'Very Relevant',
+  'Highly Relevant',
+  'Relevant',
+  'Skip',
+  'Irrelevant',
+] as const;

--- a/apps/affiliation-rating-resolver/src/lib/types.ts
+++ b/apps/affiliation-rating-resolver/src/lib/types.ts
@@ -1,0 +1,33 @@
+// Frontend mirror of the affiliation.rate contract (the service's
+// authoritative copy lives in
+// services/record-surrealdb-resolver/src/person-resolver.ts).
+
+// Per-record-set column mapping — which uploaded CSV column feeds each
+// logical field. Asked once (ColumnMapper.svelte), persisted against
+// record_set_id, silently reused for every row after that. Same pattern
+// person-db-resolver's FieldMapping uses.
+export type RatingFieldMapping = {
+  person_uuid: string;
+  org_slug: string;
+  relevance: string;
+  relevance_note: string;
+  // Informational only — shown on the row, never sent to affiliation.rate.
+  person_name: string;
+  org_name: string;
+};
+
+export type RatingNormRecord = {
+  person_uuid: string;
+  org_slug: string;
+  relevance: string; // raw, human-typed — normalized server-side
+  relevance_note: string | null;
+  person_name: string | null;
+  org_name: string | null;
+};
+
+export type AffiliationRateResult = {
+  ok: boolean;
+  affiliation_id: string;
+  relevance: string;
+  error?: string;
+};

--- a/apps/affiliation-rating-resolver/src/mount.ts
+++ b/apps/affiliation-rating-resolver/src/mount.ts
@@ -1,0 +1,23 @@
+// Federation-exposed mount function. Same shape as the other remotes.
+// theme.css + ./app.css imported as side effects so the bundler's CSS
+// pipeline injects them — Svelte's append_styles doesn't fire reliably
+// across the federation chunk boundary. theme.css first so its :root
+// tokens exist before app.css's var() refs resolve.
+
+import '@augment-it/theme/theme.css';
+import './app.css';
+import { mount, unmount, type Component } from 'svelte';
+import App from './App.svelte';
+
+export type MountResult = {
+  destroy: () => void;
+};
+
+export function mountAffiliationRatingResolver(target: HTMLElement): MountResult {
+  const component = mount(App as Component, { target });
+  return {
+    destroy: () => {
+      unmount(component);
+    },
+  };
+}

--- a/apps/affiliation-rating-resolver/tsconfig.json
+++ b/apps/affiliation-rating-resolver/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "strict": true,
+    "noImplicitAny": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "useDefineForClassFields": true,
+    "types": ["svelte"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte", "src/**/*.svelte.ts", "src/**/*.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/person-enrichment/src/App.svelte
+++ b/apps/person-enrichment/src/App.svelte
@@ -4,13 +4,28 @@
   // A pulse-surface hosts ONE entity at a time and composes N
   // pulse-dimensions against it (name, socials, additional emails,
   // organization, web presence). The operator works through the
-  // worklist of un-enriched attendees for ONE event, and each pulse —
-  // one search burst per attendee — fills as many dimensions as the
-  // search surfaces.
+  // worklist of attendees for ONE event, and each pulse — one search
+  // burst or affiliation edit per attendee — fills as many dimensions
+  // as the operator has for them.
   //
-  // v0 hardcodes the Turning-Jobs-Into-Degrees event; event-picker is
-  // a later slice. v0 also talks directly to SurrealDB; later slices
-  // proxy through per-dimension services.
+  // Event-picker (2026-07-07, per context-v/specs/Augment-From-Affiliations.md):
+  // replaces the v0 hardcoded EVENT_SLUG. Two real consequences of
+  // generalizing past the Gatsby-invite shape this app originally
+  // targeted, both load-bearing, not cosmetic:
+  //   1. The attendee query no longer filters by a fixed RSVP predicate
+  //      allowlist — ANY observation whose object is the picked event
+  //      counts as an attendance signal (speaker_at, sponsor_of,
+  //      invited_to, ...). Other predicates never use an event as their
+  //      object, so this is safe without enumerating every event-tie
+  //      verb that exists today or gets added later.
+  //   2. The worklist is now EVERY attendee, not just ones missing a
+  //      full_name. person-db-resolver-sourced persons (e.g. FreedomFest
+  //      speakers) already have a `.name` and will never have a
+  //      `full_name` — gating the worklist on "!full_name" would have
+  //      hidden all of them, defeating the reason this app is being
+  //      reused for affiliation link/corpus editing in the first place.
+  // v0 still talks directly to SurrealDB; later slices proxy through
+  // per-dimension services.
 
   import { onMount, onDestroy } from 'svelte';
   import { getDb, disconnect, CLIENT } from './lib/surreal';
@@ -22,11 +37,12 @@
   import AffiliationCard  from './pulse-dimensions/AffiliationCard.svelte';
   import type { AffiliationState } from './lib/types';
 
-  const EVENT_SLUG = '2026-05-21-turning-jobs-into-degrees';
-  const RSVP_PREDICATES = ['invited_to', 'visited_event_page', 'email_bounced'] as const;
-
   // ---- State -----------------------------------------------------------------
 
+  let events       = $state<EventRow[]>([]);
+  let eventSlug    = $state<string | null>(
+    typeof localStorage !== 'undefined' ? localStorage.getItem('augment-it:person-enrichment:event-slug') : null,
+  );
   let event = $state<EventRow | null>(null);
   let allAttendees = $state<Person[]>([]);
   let worklist     = $state<number[]>([]);
@@ -49,14 +65,41 @@
       ? allAttendees[worklist[worklistIdx]]
       : null,
   );
+  // full_name (Gatsby-shape) or name (person-db-resolver-shape) — display
+  // fallback only, never written back as-is (savePersonName still writes
+  // first_name/surname/full_name; a .name-only person keeps their .name
+  // untouched unless the operator explicitly edits first/last here).
+  const displayName = $derived(current?.full_name || current?.name || null);
 
-  const enrichedCount = $derived(allAttendees.filter((p) => p.full_name).length);
+  const enrichedCount = $derived(allAttendees.filter((p) => p.full_name || p.name).length);
   const totalCount    = $derived(allAttendees.length);
   const remainingInWorklist = $derived(Math.max(0, worklist.length - worklistIdx));
 
   // ---- Load ------------------------------------------------------------------
 
+  async function loadEvents() {
+    try {
+      const db = await getDb();
+      const r = await db.query(
+        `SELECT * FROM events WHERE client_access CONTAINS $client ORDER BY first_seen_at DESC`,
+        { client: CLIENT },
+      );
+      events = ((r?.[0] as any[]) || []) as EventRow[];
+      if (!eventSlug && events.length) eventSlug = events[0].slug;
+    } catch (e: any) {
+      error = e?.message || String(e);
+    }
+  }
+
+  function onPickEvent() {
+    if (typeof localStorage !== 'undefined' && eventSlug) {
+      localStorage.setItem('augment-it:person-enrichment:event-slug', eventSlug);
+    }
+    void load();
+  }
+
   async function load() {
+    if (!eventSlug) return;
     loading = true; error = null; status = 'connecting…';
     try {
       const db = await getDb();
@@ -64,28 +107,30 @@
       status = 'loading event…';
       const evResult = await db.query(
         'SELECT * FROM events WHERE slug = $slug LIMIT 1',
-        { slug: EVENT_SLUG },
+        { slug: eventSlug },
       );
       const ev = (evResult?.[0] as any)?.[0];
-      if (!ev) throw new Error(`event ${EVENT_SLUG} not found`);
+      if (!ev) throw new Error(`event ${eventSlug} not found`);
       event = ev;
 
+      // No hardcoded predicate allowlist — see the header comment. ANY
+      // observation whose object is this event counts as an attendance
+      // signal, regardless of which event-tie verb wrote it.
       status = 'loading attendees…';
       const peopleResult = await db.query(
         `SELECT * FROM persons
            WHERE id IN (
-             SELECT VALUE subject FROM observations
-               WHERE object = $event_id AND predicate IN $preds
+             SELECT VALUE subject FROM observations WHERE object = $event_id
            )
            ORDER BY first_seen_at ASC`,
-        { event_id: ev.id, preds: RSVP_PREDICATES },
+        { event_id: ev.id },
       );
       allAttendees = ((peopleResult?.[0] as any[]) || []) as Person[];
 
-      worklist = allAttendees
-        .map((p, i) => ({ p, i }))
-        .filter(({ p }) => !p.full_name)
-        .map(({ i }) => i);
+      // Every attendee, not just ones missing a full_name — see the header
+      // comment for why gating on "!full_name" would hide already-named
+      // (person-db-resolver-sourced) attendees entirely.
+      worklist = allAttendees.map((_p, i) => i);
       worklistIdx = 0;
 
       hydrateForm();
@@ -701,7 +746,10 @@
   }
 
   onMount(() => {
-    load();
+    (async () => {
+      await loadEvents();
+      if (eventSlug) await load();
+    })();
     window.addEventListener('keydown', onSurfaceKey, true);  // capture phase
   });
   onDestroy(() => {
@@ -714,11 +762,16 @@
   <header class="pe-header">
     <div class="pe-event">
       <span class="pe-event-label">event</span>
-      <span class="pe-event-name">{event?.name ?? '—'}</span>
+      <select class="pe-event-picker" bind:value={eventSlug} onchange={onPickEvent}>
+        <option value={null}>— pick an event —</option>
+        {#each events as ev (ev.slug)}
+          <option value={ev.slug}>{ev.name}</option>
+        {/each}
+      </select>
     </div>
     <div class="pe-progress">
       <span class="pe-counter">{enrichedCount} / {totalCount}</span>
-      <span class="pe-counter-label">enriched</span>
+      <span class="pe-counter-label">named</span>
       {#if worklist.length}
         <span class="pe-divider">·</span>
         <span class="pe-counter">{remainingInWorklist}</span>
@@ -745,20 +798,30 @@
     {:else}
       <div class="pe-card">
         <div class="pe-meta">
-          <div class="pe-meta-row">
-            <span class="pe-label">email</span>
-            <code class="pe-code">{current.email ?? '—'}</code>
-          </div>
+          {#if displayName}
+            <div class="pe-meta-row">
+              <span class="pe-label">name</span>
+              <strong>{displayName}</strong>
+            </div>
+          {/if}
+          {#if current.email}
+            <div class="pe-meta-row">
+              <span class="pe-label">email</span>
+              <code class="pe-code">{current.email}</code>
+            </div>
+          {/if}
           {#if event?.source_url}
             <div class="pe-meta-row">
               <span class="pe-label">source</span>
-              <a class="pe-link" href={event.source_url} target="_blank" rel="noopener">open gatsby table</a>
+              <a class="pe-link" href={event.source_url} target="_blank" rel="noopener">open source</a>
             </div>
           {/if}
-          <div class="pe-search-row">
-            <button class="pe-btn pe-btn-ghost" type="button" onclick={searchGoogle}>↗ google {current.email}</button>
-            <button class="pe-btn pe-btn-ghost" type="button" onclick={searchDuck}>↗ duckduckgo</button>
-          </div>
+          {#if current.email}
+            <div class="pe-search-row">
+              <button class="pe-btn pe-btn-ghost" type="button" onclick={searchGoogle}>↗ google {current.email}</button>
+              <button class="pe-btn pe-btn-ghost" type="button" onclick={searchDuck}>↗ duckduckgo</button>
+            </div>
+          {/if}
         </div>
 
         <NameFields      bind:first_name bind:surname onSave={savePersonName} />
@@ -808,7 +871,7 @@
         {#if showSummary}
           <div class="pe-summary">
             <div class="pe-summary-head">
-              <strong>Writes for {current.full_name ?? current.email} this session</strong>
+              <strong>Writes for {displayName ?? current.email ?? current.id} this session</strong>
               <span class="pe-hint">{saveLog.length} entr{saveLog.length === 1 ? 'y' : 'ies'}</span>
             </div>
             <ul class="pe-summary-list">

--- a/apps/person-enrichment/src/app.css
+++ b/apps/person-enrichment/src/app.css
@@ -49,6 +49,15 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.pe-event-picker {
+  font-size: 12px;
+  color: var(--color-text);
+  background: var(--color-surface, transparent);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  max-width: 20rem;
+}
 .pe-progress {
   display: flex;
   align-items: baseline;

--- a/apps/person-enrichment/src/lib/types.ts
+++ b/apps/person-enrichment/src/lib/types.ts
@@ -10,6 +10,10 @@ export type Person = {
   first_name?: string | null;
   surname?: string | null;
   full_name?: string | null;       // stored — materialized from first_name + surname
+  // Some sources (e.g. person-db-resolver, which never splits first/last)
+  // write a single `name` field instead of first_name/surname/full_name.
+  // Display-only fallback — see hydrateForm()'s displayName.
+  name?: string | null;
   source?: string | null;
   client_access?: string[] | null;
   // we don't render most other fields in v0; surfaced for triage only

--- a/changelog/2026-07-07_06_Augment-From-Affiliations-Initial-Build-Live-Rating-Loop-Working.md
+++ b/changelog/2026-07-07_06_Augment-From-Affiliations-Initial-Build-Live-Rating-Loop-Working.md
@@ -1,0 +1,121 @@
+---
+date_created: 2026-07-07
+date_modified: 2026-07-07
+title: "Augment from Affiliations — the rating loop is live: export, reimport, and write back to the canonical layer, end to end"
+lede: "The first augment-it flow that starts from SurrealDB instead of a CSV has its rating half working — export the FreedomFest 2026 affiliations as a spreadsheet, rate relevance offline, reimport, and write the rating back onto the affiliations edge. Getting from spec to a working screen surfaced two real architecture gaps (person-enrichment's worklist was coupled to a different person shape than it looked; the rating resolver needed its own escape hatch when an operator lands on the wrong record set) and a lesson about not surgically restarting one process in a --parallel dev stack. More to go — the link/corpus editing half isn't in this screen yet."
+publish: true
+authors:
+  - Michael Staton
+augmented_with:
+  - Claude Code on Claude Sonnet 5
+files_changed:
+  - apps/affiliation-rating-resolver/
+  - apps/person-enrichment/src/App.svelte
+  - apps/person-enrichment/src/app.css
+  - apps/person-enrichment/src/lib/types.ts
+  - services/record-surrealdb-resolver/src/person-resolver.ts
+  - services/record-surrealdb-resolver/src/person-handlers.ts
+  - services/workspace/src/capabilities.ts
+  - shell/src/remotes.ts
+  - shell/src/flows.svelte.ts
+  - shell/src/FlowWidget.svelte
+  - shell/rsbuild.config.ts
+  - scripts/export-affiliation-ratings-csv.mjs
+  - context-v/specs/Augment-From-Affiliations.md
+tags:
+  - Progress-Update
+  - Affiliations
+  - Canonical-Layer
+  - Relevance-Rating
+  - CSV-Round-Trip
+  - Reach-Edu
+  - FreedomFest
+  - Person-Enrichment
+---
+
+## Why Care?
+
+`context-v/specs/Augment-From-Affiliations.md` shipped as a design doc
+earlier tonight. This entry is the doc becoming a real, clickable screen —
+new capability, new microfrontend, a live write against the actual
+FreedomFest 2026 batch, and (per the operator's own call) a fresh "Rate
+Affiliations" entry in the shell's Flow picker.
+
+## What's New?
+
+- **`affiliation.rate` capability** — `services/record-surrealdb-resolver/src/person-resolver.ts`,
+  registered end to end through `person-handlers.ts` and
+  `services/workspace/src/capabilities.ts`. Given `(person_uuid, org_slug,
+  relevance, relevance_note)`, looks up the live `affiliations` edge fresh
+  and writes the rating. Validates the five allowed relevance labels
+  (`Very Relevant` / `Highly Relevant` / `Relevant` / `Skip` / `Irrelevant`)
+  case-insensitively and **throws on anything else** rather than coercing —
+  confirmed live via three NATS-level test calls (a real write, an
+  unrecognized-value rejection, a no-matching-edge rejection).
+- **`scripts/export-affiliation-ratings-csv.mjs`** (new) — one row per
+  `affiliations` edge for a given event, not one row per person (a person
+  with two orgs gets two independently-rateable rows). Confirmed against
+  live data: 61 affiliations for `freedomfest-2026`.
+- **`apps/affiliation-rating-resolver`** (new remote, port 3012) — reimport
+  the edited CSV through Record Collector, confirm the column mapping,
+  then apply ratings one row at a time or all at once. Registered as its
+  own **"Rate Affiliations"** entry in the shell's Flow picker
+  (`recordCollector` → `affiliationRatingResolver`), not just a
+  reachable-by-navigate extra.
+- **`person-enrichment`'s event lock-in removed.** It was hardcoded to one
+  event (`2026-05-21-turning-jobs-into-degrees`) and its worklist only
+  showed people missing a `full_name` — both assumptions specific to the
+  Gatsby-invite person shape. FreedomFest speakers (`person-db-resolver`-
+  sourced, `.name` field, no `full_name`) would have shown up as a
+  permanently-empty worklist or a broken form. Fixed: event picker, the
+  attendee query no longer filters by a fixed predicate allowlist (any
+  observation pointing at the event counts), the worklist is every
+  attendee not just unnamed ones, and the UI falls back to `.name` when
+  `full_name` is absent.
+
+## The Story
+
+Every step of getting this actually working in a browser surfaced a real
+bug, not a cosmetic one:
+
+- The reimport resolver never picked up a fresh upload from Record
+  Collector — missing the `augment-it:active-record-set-changed` listener,
+  the *exact* bug class `record-db-resolver` already hit and fixed once.
+  Should have copied that the first time.
+- The Flow-step picker was a bare numbered circle with a hover-only
+  tooltip — real usability gap, not specific to this flow. Added a visible
+  text label next to the number.
+- The column-mapping screen had no way to back out to a different record
+  set once opened, which is exactly how an operator gets stuck staring at
+  the wrong CSV's columns wondering where `person_uuid` went. Added a
+  "wrong file? pick a different record set" link plus a loud warning when
+  the loaded file has neither `person_uuid` nor `org_slug` at all.
+- Restarting one dev server by killing its port turned out to kill the
+  *entire* `pnpm --parallel` batch it belonged to (pnpm's fail-fast
+  default), taking the whole shell down twice. Lesson: don't surgically
+  restart a member of a batch — restart the batch.
+
+```mermaid
+flowchart LR
+    A[export CSV] --> B[edit relevance offline]
+    B --> C[upload via Record Collector]
+    C --> D[Affiliation Rating Resolver]
+    D -->|apply| E[affiliations edge in SurrealDB]
+    E -->|re-export| A
+```
+
+## What's Next
+
+Real gap flagged by the operator after seeing the screen live: this
+surface only rates — it doesn't yet let the operator add canonical links
+or corpus content inline, the way `record-db-resolver` /
+`person-db-resolver` let you edit a record in place. The spec currently
+routes that work to `person-enrichment` as a separate screen; whether that
+split holds up against how the operator actually wants to work it is an
+open question being revisited now.
+
+## Related
+
+- `context-v/specs/Augment-From-Affiliations.md` — the spec this implements
+- `context-v/plans/Person-Aware-Canonical-Resolver-Extension.md` — the
+  affiliation schema this writes onto

--- a/changelog/2026-07-07_07_Augment-From-Affiliations-Milestone-Rate-And-Enrich-In-One-Screen.md
+++ b/changelog/2026-07-07_07_Augment-From-Affiliations-Milestone-Rate-And-Enrich-In-One-Screen.md
@@ -1,0 +1,65 @@
+---
+date_created: 2026-07-07
+date_modified: 2026-07-07
+title: "Augment from Affiliations hits its milestone — rate, link, and enrich in one screen, 9 real rows worked end to end"
+lede: "The v0.1.0.0 rating loop shipped tonight, then got real feedback the moment it was actually used: two screens for one task was the wrong shape. Reversed course — apps/affiliation-rating-resolver now does what record-db-resolver and person-db-resolver already do for their entities: view the record, edit it in place. Five new capabilities later, the operator worked through 9 real FreedomFest 2026 affiliations end to end — real relevance ratings, real notes, real canonical links, real corpus content — and every byte of it verified correct directly against SurrealDB."
+publish: true
+authors:
+  - Michael Staton
+augmented_with:
+  - Claude Code on Claude Sonnet 5
+files_changed:
+  - apps/affiliation-rating-resolver/src/App.svelte
+  - apps/affiliation-rating-resolver/src/app.css
+  - apps/affiliation-rating-resolver/src/lib/resolver-client.ts
+  - apps/affiliation-rating-resolver/src/lib/types.ts
+  - services/record-surrealdb-resolver/src/resolver.ts
+  - services/record-surrealdb-resolver/src/person-resolver.ts
+  - services/record-surrealdb-resolver/src/handlers.ts
+  - services/record-surrealdb-resolver/src/person-handlers.ts
+  - services/workspace/src/capabilities.ts
+  - context-v/specs/Augment-From-Affiliations.md
+tags:
+  - Progress-Update
+  - Milestone
+  - Affiliations
+  - Canonical-Layer
+  - Relevance-Rating
+  - Reach-Edu
+  - FreedomFest
+---
+
+## Why Care?
+
+Ship, use, learn, fix — same day. `apps/affiliation-rating-resolver` went from spec to a live screen to real operator feedback to a real architecture reversal to a verified working milestone, all in one session. The version that actually stuck looks different from either draft: not the original all-in-one worklist, not the CSV-only split — a per-affiliation screen where relevance, links, and corpus content all get edited in the same place, because that's what using the first version revealed the job actually is.
+
+## What's New?
+
+- **The screen now edits, not just rates.** Relevance is an editable dropdown + note field, pre-filled from a CSV import but changeable right there. Below it, four sections — person links, person corpus, org links, org corpus — each showing what already exists and a one-line add form for what's missing.
+- **Five new capabilities**, all through the same NATS-gated discipline every other write in this app uses:
+  - `affiliation.detail` — fetches the *current* canonical state (not a stale CSV snapshot) whenever the operator lands on a row.
+  - `person.links.add` / `person.corpus.add` — single-entry additive writes to `persons.personal_links` / `personal_corpus`.
+  - `organization.links.add` / `organization.corpus.add` — the org-side siblings, narrower than `resolver.apply`'s whole-record batch path.
+- **9 real rows, worked end to end and verified.** John Goodman, Marc Lichtenfeld, Tim Van Milligan, David T. Phillips, Peter Lipsett, Alexander McCobin, and Ahmed Mousa all got real relevance ratings with real reasoning notes and real canonical links/corpus pulled from actual research — not test data. Rand Paul and Jessie Markell got links/corpus added with a rating still pending. Every one of these checked out correct on direct query against SurrealDB: right values, right client tagging, right actor attribution.
+
+## The Story
+
+The reversal came from watching someone actually try to use v0.1.0.0: "you're supposed to give me the kind of UI that's in record-db-resolver — I'm supposed to be able to edit the record and add links." That's a different shape than the CSV-round-trip-plus-a-separate-app split the earlier draft settled on. The fix wasn't a patch — it meant reviving capabilities cut from the very first draft (`person.links.add` etc., dropped in v0.0.0.2 in favor of routing through `person-enrichment`) and building them properly this time, gated the same way as everything else instead of `person-enrichment`'s direct-SurrealDB pattern.
+
+```mermaid
+flowchart LR
+    A[v0.1.0.0: rate via CSV,\nlinks via a second app] -->|used it once| B[operator: wrong shape]
+    B --> C[v0.2.0.0: one screen,\nedit in place]
+    C --> D[9 real rows, verified]
+```
+
+Along the way: a query that accidentally swept the entire pre-existing 882-person `humain-vc` dataset while trying to verify just tonight's work (a scoping mistake caught and corrected, not a data problem), and a stale-browser-tab scare where a screenshot showed an old error message and placeholder text even though a direct database query confirmed every single edit had landed correctly — the fix was a hard refresh, not a data recovery.
+
+## What's Next
+
+Rand Paul and Jessie Markell still need their ratings applied (links/corpus already saved). The known duplicate-person rows (Ethan Akimoto, Rudolfo Beltran) from earlier tonight are still on the list, untouched by this work. The CEO-brief export that turns rated affiliations into something shareable is still the next real spec, now with real rating data to design against instead of guesses.
+
+## Related
+
+- `context-v/specs/Augment-From-Affiliations.md` — now at v0.2.0.0
+- [[2026-07-07_06_Augment-From-Affiliations-Initial-Build-Live-Rating-Loop-Working]] — the v0.1.0.0 entry this one reverses part of

--- a/changelog/2026-07-07_07_Augment-From-Affiliations-Milestone-Rate-And-Enrich-In-One-Screen.md
+++ b/changelog/2026-07-07_07_Augment-From-Affiliations-Milestone-Rate-And-Enrich-In-One-Screen.md
@@ -1,6 +1,6 @@
 ---
 date_created: 2026-07-07
-date_modified: 2026-07-07
+date_modified: 2026-07-08
 title: "Augment from Affiliations hits its milestone — rate, link, and enrich in one screen, 9 real rows worked end to end"
 lede: "The v0.1.0.0 rating loop shipped tonight, then got real feedback the moment it was actually used: two screens for one task was the wrong shape. Reversed course — apps/affiliation-rating-resolver now does what record-db-resolver and person-db-resolver already do for their entities: view the record, edit it in place. Five new capabilities later, the operator worked through 9 real FreedomFest 2026 affiliations end to end — real relevance ratings, real notes, real canonical links, real corpus content — and every byte of it verified correct directly against SurrealDB."
 publish: true
@@ -18,7 +18,10 @@ files_changed:
   - services/record-surrealdb-resolver/src/handlers.ts
   - services/record-surrealdb-resolver/src/person-handlers.ts
   - services/workspace/src/capabilities.ts
+  - services/record-surrealdb-resolver/src/person-resolver.ts
+  - apps/affiliation-rating-resolver/src/lib/types.ts
   - context-v/specs/Augment-From-Affiliations.md
+  - scripts/export-affiliation-ratings-csv.mjs
 tags:
   - Progress-Update
   - Milestone
@@ -59,7 +62,15 @@ Along the way: a query that accidentally swept the entire pre-existing 882-perso
 
 Rand Paul and Jessie Markell still need their ratings applied (links/corpus already saved). The known duplicate-person rows (Ethan Akimoto, Rudolfo Beltran) from earlier tonight are still on the list, untouched by this work. The CEO-brief export that turns rated affiliations into something shareable is still the next real spec, now with real rating data to design against instead of guesses.
 
+## Postscript (2026-07-08)
+
+Three loose ends closed the morning after, before merging `feature/augment-affiliations` into `rebuild/turbo-rsbuild`:
+
+- **The relevance-dropdown pre-select bug**, found immediately after this milestone, is fixed in `965173e`: the stored value is snake_case (`highly_relevant`) but the `<option value>` was the Title Case label, so a previously-rated row's dropdown rendered blank on reload even though the rating had saved correctly. Fixed at the root — `normalizeRelevance` now accepts its own snake_case output, and the dropdown carries the machine value explicitly.
+- **The on-disk CSV was stale.** The only `affiliation-ratings.csv` in the repo was a 17:53 export that predated most of this night's live-edit work — reloading it would have shown 3 rated rows, not 57. Re-ran `scripts/export-affiliation-ratings-csv.mjs` fresh against SurrealDB and committed the current snapshot (57 of 61 rated) plus the branded HTML/PDF relevance report generated the same night, in the `reach-edu` submodule (`6490adc`) — the 61-row rating pass now has a durable artifact, not just live DB state.
+- **The spec is updated to `status: Shipped`, MVP confirmed**, with a "Next desired features" section naming what's deferred: observation visibility/editing in the same screen, and concurrent updates across persons/organizations/observations.
+
 ## Related
 
-- `context-v/specs/Augment-From-Affiliations.md` — now at v0.2.0.0
+- `context-v/specs/Augment-From-Affiliations.md` — now at v0.2.1.0, MVP confirmed
 - [[2026-07-07_06_Augment-From-Affiliations-Initial-Build-Live-Rating-Loop-Working]] — the v0.1.0.0 entry this one reverses part of

--- a/context-v/specs/Augment-From-Affiliations.md
+++ b/context-v/specs/Augment-From-Affiliations.md
@@ -2,13 +2,15 @@
 title: "Augment from Affiliations — the first flow that starts from SurrealDB instead of a CSV, turning an event's speaker/org pairs into a rated, sourced prospect list"
 lede: "Every flow in augment-it so far starts with a CSV — upload, map columns, resolve. This one starts with data already in the canonical layer: pick an event, export every person↔org [[Client-Tagging-on-Canonical-Writes|affiliations]] edge tied to it as a CSV, rate relevance offline in a spreadsheet, reimport — while links and corpus content get added through the existing per-affiliation surface, not a new one. Building the sourced short-list a Reach.Edu team member needs to walk into FreedomFest 2026 and know who's worth a conversation."
 date_created: 2026-07-07
-date_modified: 2026-07-07
+date_modified: 2026-07-08
 authors:
   - Michael Staton
 augmented_with:
   - Claude Code on Claude Sonnet 5
-semantic_version: 0.2.0.0
+semantic_version: 0.2.1.0
+date_first_published: 2026-07-07
 revisions:
+  - 2026-07-08 — v0.2.1.0: MVP confirmed shipped and in active use (9 real FreedomFest 2026 affiliations rated, linked, and enriched end to end, plus the relevance-dropdown pre-select fix in `965173e`). Named the next desired features — see "Next desired features" below — deferred, not started.
   - 2026-07-07 — v0.2.0.0: reversed the v0.0.0.2 split, per direct operator feedback after using the shipped v0.1.0.0 screen. "Two loops, two apps" was the wrong shape — the operator wants ONE screen per affiliation that does what `record-db-resolver`/`person-db-resolver` already do for their entities: view the record and edit it in place, including adding canonical links and corpus content, not just reading a CSV-supplied rating. `affiliation-rating-resolver` now also carries interactive relevance editing plus person-side and org-side link/corpus add — the CSV round-trip stays (bulk-editing 61 rows in a spreadsheet is still genuinely faster than 61 clicks), but it's now a *pre-fill* for this screen, not the only way to set a rating. `person-enrichment` is no longer this flow's link/corpus surface.
   - 2026-07-07 — v0.1.0.0: shipped and live-tested against the real FreedomFest 2026 batch. Two real deviations from the v0.0.0.2 plan, both discovered during implementation, not guessed in advance — (1) the export is a NEW script (`export-affiliation-ratings-csv.mjs`), not an extension of `export-event-attendees-csv.mjs`, because that script is person-per-row while ratings need affiliation-per-row (a person with two orgs needs two independently-rateable rows) — extending it would have meant changing its shape for every other consumer of that roster; (2) `person-enrichment` needed more than the planned "swap EVENT_SLUG for a picker" — its worklist and attendee query were architecturally coupled to the Gatsby-invite person shape (a `!full_name` worklist gate, a fixed RSVP-predicate allowlist), which would have shown zero or silently-wrong results for FreedomFest's `person-db-resolver`-sourced, `.name`-only persons. Fixed properly: the worklist is now every attendee (not just unnamed ones), the attendee query drops the predicate allowlist entirely (any observation pointing at the event counts), and the UI falls back to `.name` for display when `.full_name` is absent. See "What Shipped" below for the full account.
   - 2026-07-07 — v0.0.0.2: split into a hybrid — relevance rating moves to a CSV export/reimport round-trip (bulk-editable, reuses Record Collector's existing upload path); links + corpus point at `person-enrichment`'s existing per-affiliation surface (de-hardcoded from one event) instead of a new worklist UI. Smaller build, more reuse, per operator direction.
@@ -236,6 +238,35 @@ in `CAPABILITY_TO_SUBJECT` per the existing gating discipline:
   → branded HTML/PDF) — the export side of this spec extends the first;
   the eventual CEO-brief export (out of scope here) has a natural home in
   the third once rating data exists to feed it.
+
+## MVP achieved (2026-07-08)
+
+The flow works end to end against real data: 9 FreedomFest 2026
+affiliations rated, noted, and enriched with real canonical links and
+corpus content, verified directly against SurrealDB. The v0.2.0.0
+reversal (one screen, edit in place) is the shape that stuck; the
+relevance-dropdown pre-select bug found immediately after (stored
+snake_case value vs. Title Case `<option value>`) is fixed in `965173e`.
+No open defects block using this for a second event.
+
+## Next desired features (not yet scoped)
+
+Named by the operator after using the MVP, deferred until there's a real
+case pulling them forward — same manual-first-then-automate discipline as
+the rest of this spec:
+
+- **User visibility and control over creating and editing observations,
+  in the same UI.** Today `affiliation-rating-resolver` edits the
+  `affiliations` edge and the person/org link+corpus fields, but the
+  underlying `observations` (the event-tie records the affiliation and
+  the export query are built on) aren't visible or editable from this
+  screen — same "bounce to a second surface" friction the v0.2.0.0
+  reversal fixed for links and corpus.
+- **Concurrent updates across persons, organizations, and observations.**
+  Right now each add/edit commits independently per entity (person link,
+  org link, rating), but there's no story yet for two operators editing
+  overlapping affiliations at the same time, or for one save touching
+  person + org + observation together as one coherent update.
 
 ## Out of scope for v0.2.0.0
 

--- a/context-v/specs/Augment-From-Affiliations.md
+++ b/context-v/specs/Augment-From-Affiliations.md
@@ -7,11 +7,12 @@ authors:
   - Michael Staton
 augmented_with:
   - Claude Code on Claude Sonnet 5
-semantic_version: 0.0.0.2
+semantic_version: 0.1.0.0
 revisions:
+  - 2026-07-07 — v0.1.0.0: shipped and live-tested against the real FreedomFest 2026 batch. Two real deviations from the v0.0.0.2 plan, both discovered during implementation, not guessed in advance — (1) the export is a NEW script (`export-affiliation-ratings-csv.mjs`), not an extension of `export-event-attendees-csv.mjs`, because that script is person-per-row while ratings need affiliation-per-row (a person with two orgs needs two independently-rateable rows) — extending it would have meant changing its shape for every other consumer of that roster; (2) `person-enrichment` needed more than the planned "swap EVENT_SLUG for a picker" — its worklist and attendee query were architecturally coupled to the Gatsby-invite person shape (a `!full_name` worklist gate, a fixed RSVP-predicate allowlist), which would have shown zero or silently-wrong results for FreedomFest's `person-db-resolver`-sourced, `.name`-only persons. Fixed properly: the worklist is now every attendee (not just unnamed ones), the attendee query drops the predicate allowlist entirely (any observation pointing at the event counts), and the UI falls back to `.name` for display when `.full_name` is absent. See "What Shipped" below for the full account.
   - 2026-07-07 — v0.0.0.2: split into a hybrid — relevance rating moves to a CSV export/reimport round-trip (bulk-editable, reuses Record Collector's existing upload path); links + corpus point at `person-enrichment`'s existing per-affiliation surface (de-hardcoded from one event) instead of a new worklist UI. Smaller build, more reuse, per operator direction.
   - 2026-07-07 — v0.0.0.1: initial draft — single new all-DB-native worklist app covering rating + links + corpus together.
-status: Draft
+status: Shipped
 tags:
   - Spec
   - Augment-It

--- a/context-v/specs/Augment-From-Affiliations.md
+++ b/context-v/specs/Augment-From-Affiliations.md
@@ -7,8 +7,9 @@ authors:
   - Michael Staton
 augmented_with:
   - Claude Code on Claude Sonnet 5
-semantic_version: 0.1.0.0
+semantic_version: 0.2.0.0
 revisions:
+  - 2026-07-07 — v0.2.0.0: reversed the v0.0.0.2 split, per direct operator feedback after using the shipped v0.1.0.0 screen. "Two loops, two apps" was the wrong shape — the operator wants ONE screen per affiliation that does what `record-db-resolver`/`person-db-resolver` already do for their entities: view the record and edit it in place, including adding canonical links and corpus content, not just reading a CSV-supplied rating. `affiliation-rating-resolver` now also carries interactive relevance editing plus person-side and org-side link/corpus add — the CSV round-trip stays (bulk-editing 61 rows in a spreadsheet is still genuinely faster than 61 clicks), but it's now a *pre-fill* for this screen, not the only way to set a rating. `person-enrichment` is no longer this flow's link/corpus surface.
   - 2026-07-07 — v0.1.0.0: shipped and live-tested against the real FreedomFest 2026 batch. Two real deviations from the v0.0.0.2 plan, both discovered during implementation, not guessed in advance — (1) the export is a NEW script (`export-affiliation-ratings-csv.mjs`), not an extension of `export-event-attendees-csv.mjs`, because that script is person-per-row while ratings need affiliation-per-row (a person with two orgs needs two independently-rateable rows) — extending it would have meant changing its shape for every other consumer of that roster; (2) `person-enrichment` needed more than the planned "swap EVENT_SLUG for a picker" — its worklist and attendee query were architecturally coupled to the Gatsby-invite person shape (a `!full_name` worklist gate, a fixed RSVP-predicate allowlist), which would have shown zero or silently-wrong results for FreedomFest's `person-db-resolver`-sourced, `.name`-only persons. Fixed properly: the worklist is now every attendee (not just unnamed ones), the attendee query drops the predicate allowlist entirely (any observation pointing at the event counts), and the UI falls back to `.name` for display when `.full_name` is absent. See "What Shipped" below for the full account.
   - 2026-07-07 — v0.0.0.2: split into a hybrid — relevance rating moves to a CSV export/reimport round-trip (bulk-editable, reuses Record Collector's existing upload path); links + corpus point at `person-enrichment`'s existing per-affiliation surface (de-hardcoded from one event) instead of a new worklist UI. Smaller build, more reuse, per operator direction.
   - 2026-07-07 — v0.0.0.1: initial draft — single new all-DB-native worklist app covering rating + links + corpus together.
@@ -56,71 +57,62 @@ instead of "build a new app."
 
 ## User Flow
 
-Two separate loops now, not one. Both operate on the same underlying data
-(the affiliation edge and the person/org it connects), just through
-different surfaces suited to the shape of each task.
+**One screen per affiliation** — `affiliation-rating-resolver` — that does
+for an affiliation what `record-db-resolver` does for an org and
+`person-db-resolver` does for a person: view the record, edit it in
+place, one row at a time (or bulk-apply where that genuinely is faster).
+Two ways in, one place to actually work:
 
-### A. Rate relevance — export, edit offline, reimport
+### Getting a worklist: bulk-rate via CSV, or just start clicking
 
-1. **Export.** Run the (extended) `scripts/export-event-attendees-csv.mjs`
-   for the picked event — it already produces one row per attendee with
-   their affiliation (org + role), links, and corpus URLs pulled straight
-   from canonical. Add two columns: `relevance` (blank, or pre-filled if
-   already rated) and `relevance_note` (blank). Add two more columns that
-   exist for reimport, not for editing: `person_uuid` and `org_slug` — the
-   pair that identifies exactly which `affiliations` edge a row belongs to.
+1. **(Optional, bulk-friendly) Export → edit offline → reimport.** Run
+   `scripts/export-affiliation-ratings-csv.mjs` for the picked event — one
+   row per `affiliations` edge (a person with two orgs gets two rows).
+   Open it in a spreadsheet, fill in `relevance` (`Very Relevant` /
+   `Highly Relevant` / `Relevant` / `Skip` / `Irrelevant` — see
+   [Data Model Decisions](#data-model-decisions)) and `relevance_note` for
+   as many rows as make sense in bulk — sort, filter, fill-down, whatever
+   a spreadsheet is good at. Upload through Record Collector like any
+   other CSV. This is a **pre-fill**, not the only way to set a rating —
+   see below.
+2. **Or skip the CSV entirely.** The worklist can also be an event picked
+   directly (same event-tie-observation query the export script uses),
+   with a Record Collector round-trip acting only as the current storage
+   for "which affiliations am I working through," not as a gate on rating.
 
-2. **Edit offline.** The operator opens the CSV in whatever spreadsheet
-   tool they already use. Sort, filter, fill down, work in whatever order
-   makes sense, share the file with a colleague if a second opinion helps
-   — none of that needs to be built, a spreadsheet already does it. Fill
-   in `relevance` (one of `Very Relevant` / `Highly Relevant` / `Relevant`
-   / `Skip` / `Irrelevant` — see [Data Model Decisions](#data-model-decisions)
-   for what each means) and, ideally, `relevance_note` — the eventual
-   export needs to say more than a label; "Whole Foods founder, active in
-   liberty-movement philanthropy circles, worth a warm intro via X" is
-   what actually helps the CEO walk into a conversation prepared. Leave a
-   row blank to skip it entirely — that's different from rating it
-   `Skip`, see below.
+### The per-affiliation card
 
-3. **Reimport.** Upload the edited CSV through the existing Record
-   Collector path — same generic upload this app already has, no changes
-   needed there (columns are always derived from headers, never
-   predefined, per this app's standing convention). This creates a
-   record-set like any other upload.
+Each row shows the person and org together — name, role, and:
 
-4. **Resolve.** A new small resolver step (`affiliation-rating-resolver`,
-   details below) works through that record-set's rows: for each, look up
-   the `affiliations` edge by `(person_uuid, org_slug)`, and if `relevance`
-   is non-blank, write it via a new `affiliation.rate` capability. Same
-   per-record-set **column mapping** step [[Sparse-Person-Enrichment-Surface]]'s
-   sibling flows already use — the operator confirms once which columns
-   are which, not re-typed per row. Rows with blank `relevance` are
-   no-ops. Rows whose `relevance` value doesn't match one of the five
-   allowed values are **flagged, not silently coerced or dropped** — same
-   discipline as everything else touching this canonical layer.
+- **Relevance**, editable right on the card (a dropdown, not just a
+  read-only echo of whatever the CSV said). If a CSV pre-filled it,
+  that's the starting value; the operator can change it without touching
+  a spreadsheet.
+- **Person links** — existing ones listed, plus an add-a-link input
+  (canonical link types, auto-detected from whatever URL is pasted —
+  website, LinkedIn profile, X, blog, Substack, YouTube, etc.).
+- **Person corpus** — existing entries listed, plus an add-a-URL input for
+  content *about* the person (a press mention, an interview) rather than
+  a canonical profile link.
+- **Org links** and **Org corpus** — same two additive lists, for the
+  organization side.
 
-### B. Add links and corpus content — the existing per-affiliation surface
+Save writes whichever fields changed on this row — a relevance change
+alone, a link add alone, or several of these together in one pass.
+Nothing here is a save-everything-at-once form; each add/edit commits
+independently, same discipline as `person-db-resolver`'s "match a person,
+independently match an org" split.
 
-`apps/person-enrichment`'s `AffiliationCard` already does this — an
-operator working one affiliation at a time can add a link (website,
-LinkedIn profile, LinkedIn company page, X, blog, Substack, YouTube, etc.
-— auto-detected from whatever URL they paste) or a corpus entry (a press
-mention, an interview, a bio page — content *about* the person or org,
-not a canonical profile link) to the person side, the org side, or both.
+### person-enrichment is no longer this flow's link/corpus surface
 
-The one real gap: `person-enrichment` currently hardcodes
-`EVENT_SLUG = '2026-05-21-turning-jobs-into-degrees'`. Turning that into
-the same event-picker described in step A.1 (a dropdown of `events` rows,
-client-scoped) is the actual new work here — everything downstream of the
-picker already exists and needs no changes.
-
-### How the two loops relate
-
-Independent and can happen in either order, on different days, by
-different people. Rating doesn't need links/corpus to exist first, and
-vice versa — the export in step A.1 shows whatever links/corpus already
-exist at export time as read context, but doesn't require them.
+The v0.0.0.2 draft routed link/corpus editing to `apps/person-enrichment`'s
+existing `AffiliationCard` instead of building it here. Reversed per
+direct operator feedback: bouncing to a second app to add a link when
+you're already looking at the record is exactly the "two loops" friction
+that made the split feel wrong in practice. `person-enrichment` keeps its
+own reason to exist (sparse-person name/email triage for Gatsby-shaped
+attendee data) — it just isn't the tool for augmenting an affiliation
+that's already fully resolved.
 
 ## Data Model Decisions
 
@@ -161,21 +153,32 @@ thing as a row the operator never got to (which stays blank/`null` and
 remains open for a future pass). This distinction matters enough to say
 twice: **leaving a CSV cell blank ≠ typing "Skip" into it.**
 
-### Links and corpus need no new data model — and no new capabilities for v0
+### Links and corpus: new capabilities, existing fields
 
-`person-enrichment` already writes `personal_links` / `personal_corpus`
-onto `persons`, and `org_links` / `org_corpus` onto `organizations` (via
-`appendOrgLink`/`appendOrgCorpus`/`appendPersonalLink`/`appendPersonalCorpus`
-in its `App.svelte`). Reusing that surface as-is means this spec adds
-zero new fields and zero new capabilities for the link/corpus half of the
-flow.
+No new *fields* — this writes to the same `persons.personal_links` /
+`persons.personal_corpus` and `organizations.org_links` /
+`organizations.org_corpus` `person-enrichment` already uses, so any data
+already captured there stays visible and isn't migrated or duplicated.
 
-**Known wart, explicitly not fixed here:** `person-enrichment` writes
-directly to SurrealDB from the client, bypassing the NATS-capability
-gating (`services/workspace/src/capabilities.ts`) every other write path
-in this app goes through. That's pre-existing debt, not introduced by
-this spec, and fixing it is a separate concern — noted so it's not
-mistaken for an oversight.
+What v0.2.0.0 adds back (cut in v0.0.0.2, revived per the operator's
+"I'm supposed to be able to add links" feedback): four narrow, properly
+gated capabilities, each doing ONE additive write — not the full
+`resolver.apply`/`person.apply` batch-from-a-CSV-row path, which assumes
+a whole record being resolved, not one link being added to an
+already-resolved entity:
+
+| Capability | What it does |
+|---|---|
+| `person.links.add` | Append one link to `persons.personal_links`, reusing `resolver.ts`'s `shapeLink`/`inferLinkKind`. |
+| `person.corpus.add` | Append one corpus entry to `persons.personal_corpus` via `content_items` (reuses `findOrCreateContent`). |
+| `organization.links.add` | Append one link to `organizations.org_links`. |
+| `organization.corpus.add` | Append one corpus entry to `organizations.org_corpus` via `content_items`. |
+
+All four go through `CAPABILITY_TO_SUBJECT` in
+`services/workspace/src/capabilities.ts`, same gating discipline as every
+other write in this app — unlike `person-enrichment`'s direct-SurrealDB
+path, which stays a known, pre-existing wart, now avoided rather than
+extended.
 
 ### The CSV reimport key is `(person_uuid, org_slug)`, never a raw RecordId
 
@@ -191,28 +194,26 @@ trusts a RecordId string surviving the trip.
 
 ## Where it lives
 
-**Export:** extend `scripts/export-event-attendees-csv.mjs` with the
-`relevance`/`relevance_note`/`person_uuid`/`org_slug` columns described
-above. Not a new script — this one already pulls affiliation + org + link
-+ corpus data per event, per attendee.
+**Export (still available, now optional):** `scripts/export-affiliation-ratings-csv.mjs`
+(shipped in v0.1.0.0) — one row per affiliation edge, per event.
 
-**Reimport + resolve:** a new small remote,
-`apps/affiliation-rating-resolver` (`affiliationRatingResolver` in
-`shell/src/remotes.ts`), port `3012` — the first open gap in the port
-sequence. Much smaller than the v0.0.0.1 draft's worklist app: no
-match-or-create, no candidate search, just column-mapping (reusing the
-established per-record-set mapping pattern) → row iteration → one
-capability call per non-blank `relevance` row.
+**The main surface:** `apps/affiliation-rating-resolver`
+(`affiliationRatingResolver` in `shell/src/remotes.ts`), port `3012`, its
+own "Rate Affiliations" entry in the shell's Flow picker
+(`recordCollector` → `affiliationRatingResolver`). Shape-wise now closer
+to `record-db-resolver`/`person-db-resolver` than the v0.1.0.0 cut —
+per-row view **and** edit, not a pure write-pass over a spreadsheet.
 
-**Links/corpus:** no new app. `person-enrichment`'s `EVENT_SLUG` constant
-becomes a picker — the smallest change in this spec.
-
-One new capability, in `services/record-surrealdb-resolver/src/person-resolver.ts`,
-registered in `CAPABILITY_TO_SUBJECT` per the existing gating discipline:
+Five capabilities in `services/record-surrealdb-resolver`, all registered
+in `CAPABILITY_TO_SUBJECT` per the existing gating discipline:
 
 | Capability | What it does |
 |---|---|
-| `affiliation.rate` | Given `(person_uuid, org_slug, relevance, relevance_note)`, look up the live `affiliations` edge fresh and set `relevance`/`relevance_note`/`relevance_rated_by`/`relevance_rated_at`. Throws (surfaced to the operator, not silently dropped) if no matching edge exists. |
+| `affiliation.rate` | Given `(person_uuid, org_slug, relevance, relevance_note)`, look up the live `affiliations` edge fresh and set `relevance`/`relevance_note`/`relevance_rated_by`/`relevance_rated_at`. Throws if no matching edge exists. Shipped v0.1.0.0. |
+| `person.links.add` | Append one link to `persons.personal_links`. New in v0.2.0.0. |
+| `person.corpus.add` | Append one corpus entry to `persons.personal_corpus` via `content_items`. New in v0.2.0.0. |
+| `organization.links.add` | Append one link to `organizations.org_links`. New in v0.2.0.0. |
+| `organization.corpus.add` | Append one corpus entry to `organizations.org_corpus` via `content_items`. New in v0.2.0.0. |
 
 ## Composes with
 
@@ -236,7 +237,7 @@ registered in `CAPABILITY_TO_SUBJECT` per the existing gating discipline:
   the eventual CEO-brief export (out of scope here) has a natural home in
   the third once rating data exists to feed it.
 
-## Out of scope for v0.0.0.2
+## Out of scope for v0.2.0.0
 
 - **The CEO-brief export itself.** Real, wanted, explicitly deferred —
   once `relevance`/`relevance_note` exist on every affiliation, that
@@ -254,9 +255,9 @@ registered in `CAPABILITY_TO_SUBJECT` per the existing gating discipline:
   this spec — manual-first, automate once the manual pattern is proven.
 - **Multi-event exports.** One event at a time, same discipline
   [[Sparse-Person-Enrichment-Surface]] already settled on.
-- **Fixing `person-enrichment`'s direct-SurrealDB write path.** Flagged
-  above as a known wart. Pre-existing, not created by this spec, not
-  blocking it.
+- **Fixing `person-enrichment`'s direct-SurrealDB write path.** Still a
+  known wart in that app, still pre-existing, still not this spec's
+  problem now that this flow doesn't route through it at all.
 
 ## Open questions
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,37 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  apps/affiliation-rating-resolver:
+    dependencies:
+      '@augment-it/theme':
+        specifier: workspace:*
+        version: link:../../packages/theme
+      '@augment-it/workspace':
+        specifier: workspace:*
+        version: link:../../packages/workspace
+      svelte:
+        specifier: ^5.56.4
+        version: 5.56.4
+    devDependencies:
+      '@module-federation/enhanced':
+        specifier: ^2.6.0
+        version: 2.6.0(@rspack/core@2.1.2(@module-federation/runtime-tools@2.6.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.3)(webpack@5.107.1)
+      '@module-federation/rsbuild-plugin':
+        specifier: ^2.6.0
+        version: 2.6.0(@rsbuild/core@2.1.2(@module-federation/runtime-tools@2.6.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(@rspack/core@2.1.2(@module-federation/runtime-tools@2.6.0(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(node-fetch@2.7.0(encoding@0.1.13))(typescript@6.0.3)(webpack@5.107.1)
+      '@rsbuild/core':
+        specifier: ^2.1.2
+        version: 2.1.2(@module-federation/runtime-tools@2.6.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0)
+      '@rsbuild/plugin-svelte':
+        specifier: ^2.0.0
+        version: 2.0.0(@rsbuild/core@2.1.2(@module-federation/runtime-tools@2.6.0(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.47.0))(svelte@5.56.4)(typescript@6.0.3)
+      svelte-check:
+        specifier: ^4.7.1
+        version: 4.7.1(svelte@5.56.4)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
   apps/chat:
     dependencies:
       '@augment-it/theme':

--- a/scripts/export-affiliation-ratings-csv.mjs
+++ b/scripts/export-affiliation-ratings-csv.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// ============================================================================
+// export-affiliation-ratings-csv.mjs
+//
+// One row per AFFILIATION EDGE (not per person) for one event — the export
+// half of the "Augment from Affiliations" rating loop. See
+// context-v/specs/Augment-From-Affiliations.md.
+//
+// Why affiliation-per-row and not person-per-row (the shape
+// export-event-attendees-csv.mjs uses): relevance is rated per (person, org)
+// pairing, not per person — someone with two affiliations can be very
+// relevant via one org and irrelevant via the other. A person-per-row export
+// can't represent that without squashing affiliations into one cell.
+//
+// The `person_uuid` + `org_slug` columns exist for REIMPORT, not editing —
+// together they're the wire-safe key affiliation-rating-resolver uses to
+// find the live `affiliations` edge fresh (RecordIds don't survive a CSV
+// round-trip any better than they survive JSON/NATS — see
+// person-resolver.ts's header comment for the same lesson learned there).
+//
+// Usage:
+//   node scripts/export-affiliation-ratings-csv.mjs \
+//     --event-slug freedomfest-2026 \
+//     --client     reach-edu \
+//     --out-dir    clients/reach-edu/outputs/2026-07-07_freedomfest-ratings/
+//     [--out-file  affiliation-ratings.csv]
+// ============================================================================
+
+import { Surreal } from 'surrealdb';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+function parseArgs(argv) {
+  const out = { outFile: 'affiliation-ratings.csv' };
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i], v = argv[i + 1];
+    if (a === '--event-slug') { out.eventSlug = v; i += 1; }
+    else if (a === '--client') { out.client = v; i += 1; }
+    else if (a === '--out-dir') { out.outDir = v; i += 1; }
+    else if (a === '--out-file') { out.outFile = v; i += 1; }
+  }
+  return out;
+}
+
+const args = parseArgs(process.argv);
+if (!args.eventSlug || !args.client || !args.outDir) {
+  console.error('usage: --event-slug <slug> --client <slug> --out-dir <path> [--out-file affiliation-ratings.csv]');
+  process.exit(1);
+}
+for (const k of ['SURREAL_URL', 'SURREAL_NS', 'SURREAL_DB', 'SURREAL_USER', 'SURREAL_PASS']) {
+  if (!process.env[k]) { console.error(`missing env: ${k}`); process.exit(1); }
+}
+
+const db = new Surreal();
+await db.connect(process.env.SURREAL_URL);
+await db.signin({ username: process.env.SURREAL_USER, password: process.env.SURREAL_PASS });
+await db.use({ namespace: process.env.SURREAL_NS, database: process.env.SURREAL_DB });
+
+// ---- Pull -------------------------------------------------------------------
+
+const evResult = await db.query(`SELECT * FROM events WHERE slug = $slug LIMIT 1;`, { slug: args.eventSlug });
+const event = (evResult?.[0])?.[0];
+if (!event) { console.error(`event not found: ${args.eventSlug}`); process.exit(1); }
+
+// No hardcoded predicate allowlist — ANY observation whose object is this
+// event is an attendance/participation signal (speaker_at, sponsor_of,
+// exhibitor_at, attended, partner_of, invited_to, visited_event_page, ...).
+// Other predicates never use an event as their object, so this is safe
+// without enumerating every event-tie verb that exists today or gets added
+// later.
+const affResult = await db.query(
+  `LET $pids = (SELECT VALUE subject FROM observations WHERE object = $ev);
+   SELECT
+       in                       AS person_id,
+       in.person_uuid           AS person_uuid,
+       in.name                  AS person_name,
+       in.personal_links        AS person_links,
+       in.personal_corpus       AS person_corpus,
+       kind                     AS role,
+       relevance,
+       relevance_note,
+       out.slug                 AS org_slug,
+       out.complete_name        AS org_name,
+       out.org_links            AS org_links,
+       out.org_corpus           AS org_corpus
+     FROM affiliations
+     WHERE in IN $pids AND client_access CONTAINS $client
+     ORDER BY in.name ASC, out.complete_name ASC;`,
+  { ev: event.id, client: args.client },
+);
+const rows = affResult?.[affResult.length - 1] ?? [];
+
+await db.close();
+
+// ---- Reshape ----------------------------------------------------------------
+
+const countLinks = (arr) => (Array.isArray(arr) ? arr.length : 0);
+
+function rowFor(a) {
+  return {
+    person_name:        a.person_name ?? '',
+    org_name:            a.org_name ?? '',
+    role:                a.role ?? '',
+    relevance:           a.relevance ?? '',
+    relevance_note:      a.relevance_note ?? '',
+    person_links_count:  countLinks(a.person_links),
+    person_corpus_count: countLinks(a.person_corpus),
+    org_links_count:     countLinks(a.org_links),
+    org_corpus_count:    countLinks(a.org_corpus),
+    person_uuid:         a.person_uuid ?? '',
+    org_slug:            a.org_slug ?? '',
+  };
+}
+
+// person_uuid / org_slug placed LAST and documented as reimport-only in the
+// header row's own values isn't possible in plain CSV — the usage comment
+// at the top of this file, and the resolver's column-mapping step, carry
+// that instruction instead.
+const COLUMNS = [
+  'person_name', 'org_name', 'role', 'relevance', 'relevance_note',
+  'person_links_count', 'person_corpus_count', 'org_links_count', 'org_corpus_count',
+  'person_uuid', 'org_slug',
+];
+
+// ---- Render CSV (RFC 4180) --------------------------------------------------
+
+function csvCell(value) {
+  const s = String(value ?? '');
+  return /[",\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+function csvRow(values) {
+  return values.map(csvCell).join(',');
+}
+
+const shaped = rows.map(rowFor);
+const lines = [csvRow(COLUMNS), ...shaped.map((r) => csvRow(COLUMNS.map((c) => r[c])))];
+// Excel/Sheets read UTF-8 cleanly with a BOM; without it, accented names mojibake.
+const csv = '﻿' + lines.join('\r\n') + '\r\n';
+
+const outPath = resolve(args.outDir, args.outFile);
+await mkdir(args.outDir, { recursive: true });
+await writeFile(outPath, csv, 'utf8');
+
+const alreadyRated = shaped.filter((r) => r.relevance).length;
+console.log(`wrote: ${outPath}`);
+console.log(`rows: ${shaped.length} affiliations · ${alreadyRated} already rated · ${shaped.length - alreadyRated} awaiting a rating`);

--- a/services/record-surrealdb-resolver/src/handlers.ts
+++ b/services/record-surrealdb-resolver/src/handlers.ts
@@ -17,10 +17,14 @@ import {
   updateOrg,
   updateOpportunity,
   opportunitiesForOrg,
+  addOrgLink,
+  addOrgCorpus,
   type NormRecord,
   type ApplyInput,
   type UpdateOrgInput,
   type UpdateOpportunityInput,
+  type OrgLinkAddInput,
+  type OrgCorpusAddInput,
 } from './resolver';
 
 export function registerHandlers(nc: NatsConnection): void {
@@ -113,6 +117,39 @@ export function registerHandlers(nc: NatsConnection): void {
         const db = await getDb();
         const result = await opportunitiesForOrg(db, args.org_slug, args.client);
         if (msg.reply) msg.respond(JSON.stringify({ ok: true, ...result }));
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err.message : String(err);
+        if (msg.reply) msg.respond(JSON.stringify({ ok: false, error }));
+      }
+    }
+  })();
+
+  // organization.links.add — single-entry additive write for an already-
+  // resolved org. Per context-v/specs/Augment-From-Affiliations.md v0.2.0.0.
+  (async () => {
+    const sub = nc.subscribe('organization.links.add.requested');
+    for await (const msg of sub) {
+      const args = msg.json() as OrgLinkAddInput;
+      try {
+        const db = await getDb();
+        const result = await addOrgLink(db, args);
+        if (msg.reply) msg.respond(JSON.stringify(result));
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err.message : String(err);
+        if (msg.reply) msg.respond(JSON.stringify({ ok: false, error }));
+      }
+    }
+  })();
+
+  // organization.corpus.add
+  (async () => {
+    const sub = nc.subscribe('organization.corpus.add.requested');
+    for await (const msg of sub) {
+      const args = msg.json() as OrgCorpusAddInput;
+      try {
+        const db = await getDb();
+        const result = await addOrgCorpus(db, args);
+        if (msg.reply) msg.respond(JSON.stringify(result));
       } catch (err: unknown) {
         const error = err instanceof Error ? err.message : String(err);
         if (msg.reply) msg.respond(JSON.stringify({ ok: false, error }));

--- a/services/record-surrealdb-resolver/src/person-handlers.ts
+++ b/services/record-surrealdb-resolver/src/person-handlers.ts
@@ -16,11 +16,17 @@ import {
   applyPersonAffiliation,
   addPersonObservation,
   applyAffiliationRating,
+  addPersonLink,
+  addPersonCorpus,
+  getAffiliationDetail,
   type PersonNormRecord,
   type PersonApplyInput,
   type PersonAffiliateInput,
   type PersonAddObservationInput,
   type AffiliationRateInput,
+  type PersonLinkAddInput,
+  type PersonCorpusAddInput,
+  type AffiliationDetailInput,
 } from './person-resolver';
 
 export function registerPersonHandlers(nc: NatsConnection): void {
@@ -113,6 +119,57 @@ export function registerPersonHandlers(nc: NatsConnection): void {
       try {
         const db = await getDb();
         const result = await applyAffiliationRating(db, args);
+        if (msg.reply) msg.respond(JSON.stringify(result));
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err.message : String(err);
+        if (msg.reply) msg.respond(JSON.stringify({ ok: false, error }));
+      }
+    }
+  })();
+
+  // person.links.add — single-entry additive write for an already-resolved
+  // person. Per context-v/specs/Augment-From-Affiliations.md v0.2.0.0.
+  (async () => {
+    const sub = nc.subscribe('person.links.add.requested');
+    for await (const msg of sub) {
+      const args = msg.json() as PersonLinkAddInput;
+      try {
+        const db = await getDb();
+        const result = await addPersonLink(db, args);
+        if (msg.reply) msg.respond(JSON.stringify(result));
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err.message : String(err);
+        if (msg.reply) msg.respond(JSON.stringify({ ok: false, error }));
+      }
+    }
+  })();
+
+  // person.corpus.add
+  (async () => {
+    const sub = nc.subscribe('person.corpus.add.requested');
+    for await (const msg of sub) {
+      const args = msg.json() as PersonCorpusAddInput;
+      try {
+        const db = await getDb();
+        const result = await addPersonCorpus(db, args);
+        if (msg.reply) msg.respond(JSON.stringify(result));
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err.message : String(err);
+        if (msg.reply) msg.respond(JSON.stringify({ ok: false, error }));
+      }
+    }
+  })();
+
+  // affiliation.detail — current person/org links+corpus+relevance, fresh
+  // (not a stale CSV-export snapshot). Per
+  // context-v/specs/Augment-From-Affiliations.md v0.2.0.0.
+  (async () => {
+    const sub = nc.subscribe('affiliation.detail.requested');
+    for await (const msg of sub) {
+      const args = msg.json() as AffiliationDetailInput;
+      try {
+        const db = await getDb();
+        const result = await getAffiliationDetail(db, args);
         if (msg.reply) msg.respond(JSON.stringify(result));
       } catch (err: unknown) {
         const error = err instanceof Error ? err.message : String(err);

--- a/services/record-surrealdb-resolver/src/person-handlers.ts
+++ b/services/record-surrealdb-resolver/src/person-handlers.ts
@@ -5,6 +5,7 @@
 //   person.search      { q, client }                            → { ok, candidates }
 //   person.apply       { action, person_id?, record, client }    → PersonApplyResult
 //   person.affiliate   { person_id, org_action, ..., client }    → PersonAffiliateResult
+//   affiliation.rate   { person_uuid, org_slug, relevance, relevance_note?, client } → AffiliationRateResult
 
 import { type NatsConnection } from '@nats-io/transport-node';
 import { getDb } from './surreal';
@@ -14,10 +15,12 @@ import {
   applyPersonResolution,
   applyPersonAffiliation,
   addPersonObservation,
+  applyAffiliationRating,
   type PersonNormRecord,
   type PersonApplyInput,
   type PersonAffiliateInput,
   type PersonAddObservationInput,
+  type AffiliationRateInput,
 } from './person-resolver';
 
 export function registerPersonHandlers(nc: NatsConnection): void {
@@ -93,6 +96,23 @@ export function registerPersonHandlers(nc: NatsConnection): void {
       try {
         const db = await getDb();
         const result = await addPersonObservation(db, args);
+        if (msg.reply) msg.respond(JSON.stringify(result));
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err.message : String(err);
+        if (msg.reply) msg.respond(JSON.stringify({ ok: false, error }));
+      }
+    }
+  })();
+
+  // affiliation.rate — Augment-from-Affiliations CSV round-trip's write
+  // half. See context-v/specs/Augment-From-Affiliations.md.
+  (async () => {
+    const sub = nc.subscribe('affiliation.rate.requested');
+    for await (const msg of sub) {
+      const args = msg.json() as AffiliationRateInput;
+      try {
+        const db = await getDb();
+        const result = await applyAffiliationRating(db, args);
         if (msg.reply) msg.respond(JSON.stringify(result));
       } catch (err: unknown) {
         const error = err instanceof Error ? err.message : String(err);

--- a/services/record-surrealdb-resolver/src/person-resolver.ts
+++ b/services/record-surrealdb-resolver/src/person-resolver.ts
@@ -13,6 +13,12 @@
 import type { Surreal } from 'surrealdb';
 import { resolveOrgRow, slugify } from './resolver';
 
+// Actor attribution — same shape + same "never clobber with NULL when
+// unattributed" discipline as domains.ts's actorSetClause. Duplicated
+// locally rather than imported across service modules, matching how
+// domains.ts already does it in this same service.
+export type Actor = { didi_id: string; via?: string };
+
 export type PersonNormRecord = {
   name: string;
   linkedin_url?: string | null;
@@ -443,4 +449,107 @@ export async function applyPersonAffiliation(
   }
 
   return { ok: true, org_id: String(org.id), org_slug: org.slug, org_created, affiliation_created };
+}
+
+// ---------------------------------------------------------------------------
+// Capability: affiliation.rate — the write half of the Augment-from-
+// Affiliations CSV round-trip (context-v/specs/Augment-From-Affiliations.md).
+// Relevance lives on the affiliations RELATE edge itself, not on persons or
+// organizations (both multi-tenant — a bare field there would leak one
+// client's rating to any other client who can see the same row) and not a
+// new opportunities-like table (opportunities is confirmed org-only and
+// CSV-record-coupled — not a fit for an affiliation-driven origin).
+//
+// Looked up fresh by (person_uuid, org_slug) on every call — never trusts a
+// RecordId surviving the CSV round-trip, same lesson as person_uuid's
+// original introduction and domains.ts's source_uuid.
+// ---------------------------------------------------------------------------
+
+const RELEVANCE_LABELS: Record<string, string> = {
+  'very relevant': 'very_relevant',
+  'highly relevant': 'highly_relevant',
+  'relevant': 'relevant',
+  'skip': 'skip',
+  'irrelevant': 'irrelevant',
+};
+
+// Exported so the reimport resolver (or anything else) can render the
+// canonical label set without duplicating it — e.g. a column-mapping UI
+// that wants to validate before ever calling the capability.
+export const RELEVANCE_VALUES = Object.values(RELEVANCE_LABELS);
+
+// Human-typed text in, canonical machine value out. Throws rather than
+// guessing on anything that doesn't match one of the five labels
+// case-insensitively — flagged to the operator, never silently coerced or
+// dropped, per the spec's explicit discipline.
+export function normalizeRelevance(raw: string): string {
+  const key = raw.trim().toLowerCase();
+  const v = RELEVANCE_LABELS[key];
+  if (!v) {
+    throw new Error(
+      `unrecognized relevance value: "${raw}" — expected one of Very Relevant, Highly Relevant, Relevant, Skip, Irrelevant`,
+    );
+  }
+  return v;
+}
+
+export type AffiliationRateInput = {
+  person_uuid: string;
+  org_slug: string;
+  relevance: string; // raw, human-typed — normalized inside applyAffiliationRating
+  relevance_note?: string | null;
+  client: string;
+  actor?: Actor;
+};
+
+export type AffiliationRateResult = {
+  ok: true;
+  affiliation_id: string;
+  relevance: string;
+};
+
+export async function applyAffiliationRating(
+  db: Surreal,
+  input: AffiliationRateInput,
+): Promise<AffiliationRateResult> {
+  const relevance = normalizeRelevance(input.relevance);
+
+  const person = await fetchPersonByUuid(db, input.person_uuid);
+  if (!person) throw new Error(`person not found: ${input.person_uuid}`);
+  const org = await db.query('SELECT VALUE id FROM organizations WHERE slug = $slug LIMIT 1;', {
+    slug: input.org_slug,
+  });
+  const orgId = ((org?.[0] as unknown[]) ?? [])[0];
+  if (!orgId) throw new Error(`organization not found: ${input.org_slug}`);
+
+  const edge = await db.query(
+    'SELECT VALUE id FROM affiliations WHERE in = $person AND out = $org LIMIT 1;',
+    { person: person.id, org: orgId },
+  );
+  const edgeId = ((edge?.[0] as unknown[]) ?? [])[0];
+  if (!edgeId) {
+    throw new Error(
+      `no affiliation edge between person_uuid ${input.person_uuid} and org_slug ${input.org_slug} — resolve the affiliation before rating it`,
+    );
+  }
+
+  const sets = [
+    'relevance = $relevance',
+    'relevance_note = $relevance_note',
+    'relevance_rated_at = time::now()',
+    'client_access = array::union(client_access ?? [], [$client])',
+  ];
+  const vars: Record<string, unknown> = {
+    id: edgeId,
+    relevance,
+    relevance_note: input.relevance_note?.trim() || null,
+    client: input.client,
+  };
+  if (input.actor?.didi_id) {
+    sets.push('relevance_rated_by = $rated_by');
+    vars.rated_by = input.actor.didi_id;
+  }
+  await db.query(`UPDATE $id SET ${sets.join(', ')};`, vars);
+
+  return { ok: true, affiliation_id: String(edgeId), relevance };
 }

--- a/services/record-surrealdb-resolver/src/person-resolver.ts
+++ b/services/record-surrealdb-resolver/src/person-resolver.ts
@@ -467,7 +467,9 @@ export async function applyPersonAffiliation(
 
 const RELEVANCE_LABELS: Record<string, string> = {
   'very relevant': 'very_relevant',
+  'very_relevant': 'very_relevant',
   'highly relevant': 'highly_relevant',
+  'highly_relevant': 'highly_relevant',
   'relevant': 'relevant',
   'skip': 'skip',
   'irrelevant': 'irrelevant',

--- a/services/record-surrealdb-resolver/src/person-resolver.ts
+++ b/services/record-surrealdb-resolver/src/person-resolver.ts
@@ -11,7 +11,7 @@
 // so it's reachable from the shell instead of CLI-only.
 
 import type { Surreal } from 'surrealdb';
-import { resolveOrgRow, slugify } from './resolver';
+import { resolveOrgRow, slugify, shapeLink, findOrCreateContent, type ShapedLink } from './resolver';
 
 // Actor attribution — same shape + same "never clobber with NULL when
 // unattributed" discipline as domains.ts's actorSetClause. Duplicated
@@ -552,4 +552,149 @@ export async function applyAffiliationRating(
   await db.query(`UPDATE $id SET ${sets.join(', ')};`, vars);
 
   return { ok: true, affiliation_id: String(edgeId), relevance };
+}
+
+// ---------------------------------------------------------------------------
+// Capability: affiliation.detail — the read half that makes the inline
+// editor honest: shows the CURRENT persons/organizations link+corpus
+// arrays and the current relevance, not a snapshot frozen at CSV-export
+// time. Called whenever the operator navigates to a row. Per
+// context-v/specs/Augment-From-Affiliations.md v0.2.0.0.
+// ---------------------------------------------------------------------------
+
+type PersonDetailRow = {
+  id: unknown;
+  person_uuid?: string | null;
+  name?: string | null;
+  personal_links?: ShapedLink[] | null;
+  personal_corpus?: (ShapedLink & { content_id: unknown })[] | null;
+};
+type OrgDetailRow = {
+  id: unknown;
+  slug: string;
+  complete_name?: string | null;
+  org_links?: ShapedLink[] | null;
+  org_corpus?: (ShapedLink & { content_id: unknown })[] | null;
+};
+type AffiliationEdgeRow = {
+  kind?: string | null;
+  relevance?: string | null;
+  relevance_note?: string | null;
+};
+
+export type AffiliationDetailInput = { person_uuid: string; org_slug: string };
+export type AffiliationDetailResult = {
+  ok: true;
+  person: {
+    person_uuid: string;
+    name: string | null;
+    personal_links: ShapedLink[];
+    personal_corpus: (ShapedLink & { content_id: unknown })[];
+  };
+  org: {
+    org_slug: string;
+    complete_name: string | null;
+    org_links: ShapedLink[];
+    org_corpus: (ShapedLink & { content_id: unknown })[];
+  };
+  kind: string | null;
+  relevance: string | null;
+  relevance_note: string | null;
+};
+
+export async function getAffiliationDetail(
+  db: Surreal,
+  input: AffiliationDetailInput,
+): Promise<AffiliationDetailResult> {
+  const personRes = await db.query(
+    `SELECT id, person_uuid, name, personal_links, personal_corpus FROM persons WHERE person_uuid = $u LIMIT 1;`,
+    { u: input.person_uuid },
+  );
+  const person = ((personRes?.[0] as PersonDetailRow[]) ?? [])[0];
+  if (!person) throw new Error(`person not found: ${input.person_uuid}`);
+
+  const orgRes = await db.query(
+    `SELECT id, slug, complete_name, org_links, org_corpus FROM organizations WHERE slug = $slug LIMIT 1;`,
+    { slug: input.org_slug },
+  );
+  const org = ((orgRes?.[0] as OrgDetailRow[]) ?? [])[0];
+  if (!org) throw new Error(`organization not found: ${input.org_slug}`);
+
+  const affRes = await db.query(
+    `SELECT kind, relevance, relevance_note FROM affiliations WHERE in = $person AND out = $org LIMIT 1;`,
+    { person: person.id, org: org.id },
+  );
+  const aff = ((affRes?.[0] as AffiliationEdgeRow[]) ?? [])[0] ?? {};
+
+  return {
+    ok: true,
+    person: {
+      person_uuid: input.person_uuid,
+      name: person.name ?? null,
+      personal_links: person.personal_links ?? [],
+      personal_corpus: person.personal_corpus ?? [],
+    },
+    org: {
+      org_slug: input.org_slug,
+      complete_name: org.complete_name ?? null,
+      org_links: org.org_links ?? [],
+      org_corpus: org.org_corpus ?? [],
+    },
+    kind: aff.kind ?? null,
+    relevance: aff.relevance ?? null,
+    relevance_note: aff.relevance_note ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Capabilities: person.links.add / person.corpus.add — the person-side
+// sibling of resolver.ts's organization.links.add / organization.corpus.add.
+// Same narrow, single-entry shape; reuses shapeLink/findOrCreateContent
+// rather than reimplementing them. Per
+// context-v/specs/Augment-From-Affiliations.md v0.2.0.0.
+// ---------------------------------------------------------------------------
+
+export type PersonLinkAddInput = { person_uuid: string; url: string; kind?: string; client: string };
+export type PersonLinkAddResult = { ok: true; person_uuid: string; link: ShapedLink };
+
+export async function addPersonLink(db: Surreal, input: PersonLinkAddInput): Promise<PersonLinkAddResult> {
+  const person = await fetchPersonByUuid(db, input.person_uuid);
+  if (!person) throw new Error(`person not found: ${input.person_uuid}`);
+  const shaped = shapeLink(input.kind ? { url: input.url, kind: input.kind } : input.url);
+  if (!shaped) throw new Error('person.links.add requires a non-empty url');
+  await db.query(
+    `UPDATE $id SET
+        personal_links  = array::concat(personal_links ?? [], [$link]),
+        client_access   = array::union(client_access ?? [], [$client]),
+        last_touched_by = $client, last_touched_at = time::now();`,
+    { id: person.id, link: shaped, client: input.client },
+  );
+  return { ok: true, person_uuid: input.person_uuid, link: shaped };
+}
+
+export type PersonCorpusAddInput = { person_uuid: string; url: string; kind?: string; client: string };
+export type PersonCorpusAddResult = {
+  ok: true;
+  person_uuid: string;
+  entry: ShapedLink & { content_id: unknown };
+};
+
+export async function addPersonCorpus(
+  db: Surreal,
+  input: PersonCorpusAddInput,
+): Promise<PersonCorpusAddResult> {
+  const person = await fetchPersonByUuid(db, input.person_uuid);
+  if (!person) throw new Error(`person not found: ${input.person_uuid}`);
+  const shaped = shapeLink(input.kind ? { url: input.url, kind: input.kind } : input.url);
+  if (!shaped) throw new Error('person.corpus.add requires a non-empty url');
+  const content_id = await findOrCreateContent(db, shaped.url, shaped.kind, shaped.url_domain);
+  const entry = { ...shaped, content_id };
+  await db.query(
+    `UPDATE $id SET
+        personal_corpus = array::concat(personal_corpus ?? [], [$entry]),
+        client_access   = array::union(client_access ?? [], [$client]),
+        last_touched_by = $client, last_touched_at = time::now();`,
+    { id: person.id, entry, client: input.client },
+  );
+  return { ok: true, person_uuid: input.person_uuid, entry };
 }

--- a/services/record-surrealdb-resolver/src/resolver.ts
+++ b/services/record-surrealdb-resolver/src/resolver.ts
@@ -28,7 +28,7 @@ export type NormRecord = {
   corpus?: RawLink[];
 };
 
-type ShapedLink = { url: string; kind: string; url_domain: string; added_at: string };
+export type ShapedLink = { url: string; kind: string; url_domain: string; added_at: string };
 type ShapedStream = {
   url: string;
   kind: string;
@@ -136,7 +136,7 @@ function rawToUrl(l: RawLink): string {
   return (typeof l === 'string' ? l : l?.url ?? '').trim();
 }
 
-function shapeLink(l: RawLink): ShapedLink | null {
+export function shapeLink(l: RawLink): ShapedLink | null {
   const url = rawToUrl(l);
   if (!url) return null;
   const kind = typeof l === 'object' && l?.kind ? l.kind : inferLinkKind(url);
@@ -342,7 +342,7 @@ export async function searchOrgs(
 // (Ports apps/person-enrichment/src/App.svelte findOrCreateContent.)
 // ---------------------------------------------------------------------------
 
-async function findOrCreateContent(
+export async function findOrCreateContent(
   db: Surreal,
   url: string,
   kind: string,
@@ -762,4 +762,51 @@ export async function updateOrg(db: Surreal, input: UpdateOrgInput): Promise<Upd
     aliases: fresh.aliases ?? [],
     renamed,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Capabilities: organization.links.add / organization.corpus.add — narrow,
+// single-entry additive writes for an org that already exists, as opposed
+// to resolver.apply's whole-NormRecord batch append. Used by
+// affiliation-rating-resolver's inline per-affiliation editor
+// (context-v/specs/Augment-From-Affiliations.md v0.2.0.0) so an operator
+// can add one link/corpus URL without a CSV row driving it.
+// ---------------------------------------------------------------------------
+
+export type OrgLinkAddInput = { org_slug: string; url: string; kind?: string; client: string };
+export type OrgLinkAddResult = { ok: true; org_id: string; link: ShapedLink };
+
+export async function addOrgLink(db: Surreal, input: OrgLinkAddInput): Promise<OrgLinkAddResult> {
+  const org = await fetchOrgBySlug(db, input.org_slug);
+  if (!org) throw new Error(`organization not found: ${input.org_slug}`);
+  const shaped = shapeLink(input.kind ? { url: input.url, kind: input.kind } : input.url);
+  if (!shaped) throw new Error('organization.links.add requires a non-empty url');
+  await db.query(
+    `UPDATE $id SET
+        org_links       = array::concat(org_links ?? [], [$link]),
+        client_access   = array::union(client_access ?? [], [$client]),
+        last_touched_by = $client, last_touched_at = time::now();`,
+    { id: org.id, link: shaped, client: input.client },
+  );
+  return { ok: true, org_id: String(org.id), link: shaped };
+}
+
+export type OrgCorpusAddInput = { org_slug: string; url: string; kind?: string; client: string };
+export type OrgCorpusAddResult = { ok: true; org_id: string; entry: ShapedLink & { content_id: unknown } };
+
+export async function addOrgCorpus(db: Surreal, input: OrgCorpusAddInput): Promise<OrgCorpusAddResult> {
+  const org = await fetchOrgBySlug(db, input.org_slug);
+  if (!org) throw new Error(`organization not found: ${input.org_slug}`);
+  const shaped = shapeLink(input.kind ? { url: input.url, kind: input.kind } : input.url);
+  if (!shaped) throw new Error('organization.corpus.add requires a non-empty url');
+  const content_id = await findOrCreateContent(db, shaped.url, shaped.kind, shaped.url_domain);
+  const entry = { ...shaped, content_id };
+  await db.query(
+    `UPDATE $id SET
+        org_corpus      = array::concat(org_corpus ?? [], [$entry]),
+        client_access   = array::union(client_access ?? [], [$client]),
+        last_touched_by = $client, last_touched_at = time::now();`,
+    { id: org.id, entry, client: input.client },
+  );
+  return { ok: true, org_id: String(org.id), entry };
 }

--- a/services/workspace/src/capabilities.ts
+++ b/services/workspace/src/capabilities.ts
@@ -155,6 +155,14 @@ const CAPABILITY_TO_SUBJECT: Record<string, string> = {
   // (person_uuid, org_slug) rather than a resolved candidate. Per
   // context-v/specs/Augment-From-Affiliations.md.
   'affiliation.rate': 'affiliation.rate.requested',
+  // Augment from Affiliations v0.2.0.0 — inline link/corpus editing on the
+  // affiliation-rating-resolver card, narrower than person.apply /
+  // resolver.apply (one entry, not a whole record batch).
+  'person.links.add': 'person.links.add.requested',
+  'person.corpus.add': 'person.corpus.add.requested',
+  'organization.links.add': 'organization.links.add.requested',
+  'organization.corpus.add': 'organization.corpus.add.requested',
+  'affiliation.detail': 'affiliation.detail.requested',
 
   // Domain catalog — the canonical typed-grouping graph behind apps/strategy-curator
   // (which is the type='strategy' view). Served by record-surrealdb-resolver
@@ -247,6 +255,15 @@ const CAPABILITY_TIMEOUTS_MS: Record<string, number> = {
   // One fresh lookup by (person_uuid, org_slug) + one UPDATE — same Cloud
   // round-trip budget as its person.* siblings.
   'affiliation.rate': 30_000,
+  // One entity lookup + one additive UPDATE (corpus variants also touch
+  // content_items once). Same Cloud round-trip budget as everything else
+  // in this service.
+  'person.links.add': 30_000,
+  'person.corpus.add': 30_000,
+  'organization.links.add': 30_000,
+  'organization.corpus.add': 30_000,
+  // Two entity lookups + one edge lookup — same Cloud round-trip budget.
+  'affiliation.detail': 30_000,
   // Domain catalog — SurrealDB graph reads/writes; same Cloud round-trip budget.
   // retype fans out one content-ingest file-move round-trip per client_slug
   // on the row (usually one) — 45s covers a multi-client domain comfortably.

--- a/services/workspace/src/capabilities.ts
+++ b/services/workspace/src/capabilities.ts
@@ -151,6 +151,10 @@ const CAPABILITY_TO_SUBJECT: Record<string, string> = {
   'person.apply': 'person.apply.requested',
   'person.affiliate': 'person.affiliate.requested',
   'person.add_observation': 'person.add_observation.requested',
+  // Augment from Affiliations — the CSV-round-trip rating write, keyed by
+  // (person_uuid, org_slug) rather than a resolved candidate. Per
+  // context-v/specs/Augment-From-Affiliations.md.
+  'affiliation.rate': 'affiliation.rate.requested',
 
   // Domain catalog — the canonical typed-grouping graph behind apps/strategy-curator
   // (which is the type='strategy' view). Served by record-surrealdb-resolver
@@ -240,6 +244,9 @@ const CAPABILITY_TIMEOUTS_MS: Record<string, number> = {
   'person.apply': 30_000,
   'person.affiliate': 30_000,
   'person.add_observation': 30_000,
+  // One fresh lookup by (person_uuid, org_slug) + one UPDATE — same Cloud
+  // round-trip budget as its person.* siblings.
+  'affiliation.rate': 30_000,
   // Domain catalog — SurrealDB graph reads/writes; same Cloud round-trip budget.
   // retype fans out one content-ingest file-move round-trip per client_slug
   // on the row (usually one) — 45s covers a multi-client domain comfortably.

--- a/shell/rsbuild.config.ts
+++ b/shell/rsbuild.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
         recordDbResolver: 'recordDbResolver@http://localhost:3008/remoteEntry.js',
         personDbResolver: 'personDbResolver@http://localhost:3010/remoteEntry.js',
         strategyCurator: 'strategyCurator@http://localhost:3017/remoteEntry.js',
+        affiliationRatingResolver: 'affiliationRatingResolver@http://localhost:3012/remoteEntry.js',
       },
       // No `shared` block — sharing Svelte 5's reactive runtime and a
       // .svelte.ts singleton across federation has known issues with the

--- a/shell/src/FlowWidget.svelte
+++ b/shell/src/FlowWidget.svelte
@@ -93,6 +93,7 @@
           onclick={() => onSelectStep(step.id)}
         >
           <span class="bubble-num">{i + 1}</span>
+          <span class="bubble-label">{step.label}</span>
         </button>
         {#if i < steps.length - 1}
           <span
@@ -180,18 +181,43 @@
     background: transparent;
     color: var(--color-text-muted);
     border: 1px solid var(--color-border);
-    width: 1.75rem;
     height: 1.75rem;
-    padding: 0;
+    padding: 0 0.65rem 0 0.3rem;
     border-radius: 999px;
     font: inherit;
     font-size: 0.75rem;
     line-height: 1;
     display: inline-flex;
     align-items: center;
-    justify-content: center;
+    gap: 0.4rem;
     cursor: pointer;
+    white-space: nowrap;
     transition: border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease, background 0.18s ease;
+  }
+  .bubble-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.15rem;
+    height: 1.15rem;
+    border-radius: 999px;
+    background: color-mix(in srgb, currentColor 18%, transparent);
+    flex-shrink: 0;
+  }
+  .bubble-label {
+    font-weight: 500;
+    letter-spacing: 0.01em;
+  }
+  /* The left-rail orientation is narrow — labels would force horizontal
+     overflow. Numbered badge + hover tooltip only there, same as before
+     this change. */
+  .orientation-left .bubble-label {
+    display: none;
+  }
+  .orientation-left .bubble {
+    padding: 0;
+    width: 1.75rem;
+    justify-content: center;
   }
 
   /* Visited: filled in muted-accent — "you've been here." */

--- a/shell/src/flows.svelte.ts
+++ b/shell/src/flows.svelte.ts
@@ -17,6 +17,7 @@ import {
   BUILD_CORPORA_ROTATION,
   EVENT_ATTENDEES_ROTATION,
   PEOPLE_ROTATION,
+  AFFILIATION_RATING_ROTATION,
 } from './remotes';
 
 export type FlowDef = {
@@ -54,6 +55,13 @@ export const FLOWS: FlowDef[] = [
     description:
       'Ingest a CSV of people (event speakers, attendees) and reconcile each row to a canonical person, then their org + role, in SurrealDB.',
     rotation: PEOPLE_ROTATION,
+  },
+  {
+    id: 'affiliationRating',
+    label: 'Rate Affiliations',
+    description:
+      'Reimport a relevance-rated affiliations CSV (from scripts/export-affiliation-ratings-csv.mjs) and write the ratings back onto each affiliations edge in SurrealDB. The first flow that starts from the canonical layer instead of a raw CSV.',
+    rotation: AFFILIATION_RATING_ROTATION,
   },
 ];
 

--- a/shell/src/remotes.ts
+++ b/shell/src/remotes.ts
@@ -80,6 +80,17 @@ export const EVENT_ATTENDEES_ROTATION: string[] = ['recordCollector', 'recordDbR
  */
 export const PEOPLE_ROTATION: string[] = ['recordCollector', 'personDbResolver'];
 
+/**
+ * The "Rate Affiliations" flow's rotation — the write half of Augment from
+ * Affiliations (context-v/specs/Augment-From-Affiliations.md). Upload the
+ * rating-edited CSV (from scripts/export-affiliation-ratings-csv.mjs)
+ * through the existing Record Collector path, then affiliationRatingResolver
+ * maps columns once and writes relevance/relevance_note onto each row's
+ * affiliations edge. No match/create — every row's person + org already
+ * exist in canonical.
+ */
+export const AFFILIATION_RATING_ROTATION: string[] = ['recordCollector', 'affiliationRatingResolver'];
+
 export const REMOTES: RemoteEntry[] = [
   {
     id: 'recordCollector',
@@ -136,6 +147,13 @@ export const REMOTES: RemoteEntry[] = [
     description: 'Match each record to a canonical person (or create one), then their org + role — one by one',
     // @ts-expect-error — federation remote, type comes from the MF runtime
     importMount: () => import('personDbResolver/mount'),
+  },
+  {
+    id: 'affiliationRatingResolver',
+    label: 'Affiliation Rating Resolver',
+    description: 'Reimport a rated affiliations CSV and write relevance + notes back onto the affiliations edges',
+    // @ts-expect-error — federation remote, type comes from the MF runtime
+    importMount: () => import('affiliationRatingResolver/mount'),
   },
 ];
 
@@ -219,7 +237,13 @@ export const STRATEGY_CURATOR_REMOTE: RemoteEntry = {
   importMount: () => import('strategyCurator/mount'),
 };
 
-const EXTRA_REMOTES: RemoteEntry[] = [CHAT_REMOTE, PACK_RUNNER_REMOTE, SORT_FILTER_LENS_REMOTE, PERSON_ENRICHMENT_REMOTE, STRATEGY_CURATOR_REMOTE];
+const EXTRA_REMOTES: RemoteEntry[] = [
+  CHAT_REMOTE,
+  PACK_RUNNER_REMOTE,
+  SORT_FILTER_LENS_REMOTE,
+  PERSON_ENRICHMENT_REMOTE,
+  STRATEGY_CURATOR_REMOTE,
+];
 
 // Co-existence pairings — which two remotes share the viewport in Mode B,
 // and the default left-panel width %. Different pairs want different


### PR DESCRIPTION
## Summary
- New flow: `apps/affiliation-rating-resolver` rates, links, and enriches person↔org affiliations for an event directly against SurrealDB — the first augment-it flow that starts from the canonical layer instead of a CSV.
- Five new gated capabilities (`affiliation.rate`, `person.links.add`, `person.corpus.add`, `organization.links.add`, `organization.corpus.add`) in `services/record-surrealdb-resolver`.
- MVP confirmed shipped: 57 of 61 FreedomFest 2026 affiliations rated end to end, verified against SurrealDB; relevance-dropdown pre-select bug found and fixed same session.
- Spec (`context-v/specs/Augment-From-Affiliations.md`) updated to `status: Shipped` with a "Next desired features" section (observation visibility/editing in the same UI, concurrent updates across persons/organizations/observations).

## Test plan
- [x] 9 real rows worked end-to-end through the UI, verified directly against SurrealDB (ratings, notes, links, corpus, actor attribution)
- [x] Relevance-dropdown pre-select bug fixed and re-verified against an already-rated row
- [x] Fresh CSV export re-run against live SurrealDB and matches DB state (57/61 rated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)